### PR TITLE
Logout feature

### DIFF
--- a/models/erpModels/Admin.js
+++ b/models/erpModels/Admin.js
@@ -39,7 +39,11 @@ const adminSchema = new Schema({
     default: false,
   },
   permissions: [{ type: mongoose.Schema.ObjectId, ref: 'Permission' }],
-  isLoggedIn: { type: Boolean },
+  isLoggedIn: { type: Number },
+  loggedSessions:{
+    type: [String],
+    default: []
+  },
 });
 
 adminSchema.plugin(require('mongoose-autopopulate'));


### PR DESCRIPTION
Hi @salahlalami ,

This PR fixes issue #197 

Solution:
- When a user logs in, the generated jwt gets stored in the ``loggedSessions`` field and increases ``isLoggedin`` field by 1
- When a user hits logout, ``isLoggedin`` reduces by 1, and `that token is removed from the ``loggedSessions`` array

Why this architecture of implementation?
Today everyone has multiple devices and login through them So a single user can logged in through multiple accounts.The advantages we have :
- Changing ``isLoggedin`` field to Number provides the facility to fast retrieve the number of sessions the user is logged in
-  Creating new Field ``loggedSessions`` allow us to keep track of the devices of the user , and we can use this information to extend the security system of ``idurar`` so that when any new login session came into user account we can inform him

Demonstration:
After login:
![Screenshot from 2023-07-06 11-20-22](https://github.com/idurar/idurar-erp-crm/assets/100110395/76b293b1-045c-4222-878e-66072ff5a1f0)

After Logout:
![Screenshot from 2023-07-06 11-20-38](https://github.com/idurar/idurar-erp-crm/assets/100110395/ac5a9e4c-34be-46f4-a771-b5a87693fbd0)

There is no need to store revoked token as I saw in the PR that already existed for this issue

The time complexity of these changes:- 
Login: O(1) because doing +1 in isLoggedin field and pushing at the end of an array 
Logout:  O(1) for doing -1 in isLoggedin and amortized O(1) for poping the token in loggedSessions array

> Note : the time complexity for poping loggedSessions will be amortized O(1) because the size of the array will never exceed 10 which is the active logged-in devices the user has at a particular time so it is constant 

I would like to hear any suggestions and improvements from you, so that I can improve this PR