### PR TITLE
[Fix][BackEnd] Fix NoSql Injection login API

### DIFF
--- a/controllers/erpControllers/authJwtController.js
+++ b/controllers/erpControllers/authJwtController.js
@@ -17,6 +17,7 @@ exports.login = async (req, res) => {
       // Connection is from localhost
       isLocalhost = true;
     }
+
     // validate
     if (!email || !password)
       return res.status(400).json({
@@ -24,6 +25,14 @@ exports.login = async (req, res) => {
         result: null,
         message: 'Not all fields have been entered.',
       });
+    
+    if (typeof email !== "string") {
+       return res.status(400).json({
+         success: false,
+         result: null,
+         message: 'Email must be a string.',
+       });
+    }
 
     const admin = await Admin.findOne({ email: email, removed: false });
     // console.log(admin);


### PR DESCRIPTION
# What's changed:
- [x] Validate email type when login.

# Result
When the user tries to inject something to bypass authentication to get an access token, we need to validate the input data.
```code
{
    "success": false,
    "result": null,
    "message": "Email must be a string."
}
```

# To Improve
- Need to validate all input on the FrontEnd side.
- Validate params, body in BE side(for example: use zod, joi, yup)

# Related issues: #177 