### PR TITLE
fix:fixed mobile navigation button overlap in customer page

### DIFF
--- a/frontend/src/components/SidePanel/index.jsx
+++ b/frontend/src/components/SidePanel/index.jsx
@@ -58,7 +58,6 @@ export default function SidePanel({ config, topContent, bottomContent, fixHeader
     <Sider
       trigger={<MenuOutlined className="trigger" />}
       width={400}
-      collapsible
       collapsed={isSidePanelClose}
       collapsedWidth={'0px'}
       onCollapse={collapsePanel}

--- a/frontend/src/modules/CrudModule/index.jsx
+++ b/frontend/src/modules/CrudModule/index.jsx
@@ -103,7 +103,7 @@ function FixHeaderPanel({ config }) {
         <Col className="gutter-row" span={2}>
           <Button
             style={{ marginTop: 3 }}
-            type="default"
+            type="text"
             onClick={collapsePanel}
             icon={<ArrowLeftOutlined />}
             block={true}

--- a/frontend/src/modules/CrudModule/index.jsx
+++ b/frontend/src/modules/CrudModule/index.jsx
@@ -1,6 +1,6 @@
 import React, { useLayoutEffect, useEffect, useState } from 'react';
 import { Row, Col, Button, Divider } from 'antd';
-import { PlusOutlined, EditOutlined, DeleteOutlined } from '@ant-design/icons';
+import { PlusOutlined, EditOutlined, DeleteOutlined, ArrowLeftOutlined } from '@ant-design/icons';
 
 import CreateForm from '@/components/CreateForm';
 import UpdateForm from '@/components/UpdateForm';
@@ -93,10 +93,24 @@ function FixHeaderPanel({ config }) {
     collapsedBox.close();
   };
 
+  const collapsePanel = () => {
+    panel.collapse();
+  };
+
   return (
     <div className="box">
       <Row gutter={12}>
-        <Col className="gutter-row" span={21}>
+        <Col className="gutter-row" span={2}>
+          <Button
+            style={{ marginTop: 3 }}
+            type="default"
+            onClick={collapsePanel}
+            icon={<ArrowLeftOutlined />}
+            block={true}
+            size="small"
+          ></Button>
+        </Col>
+        <Col className="gutter-row" span={22}>
           <h1 style={{ fontSize: 20, marginBottom: 20 }}>{config.PANEL_TITLE}</h1>
         </Col>
       </Row>


### PR DESCRIPTION
Fixed #305 mobile navigation button overlap in customer page by adding the back button in customer panel and removing the menu button for add new customer panel


https://github.com/idurar/idurar-erp-crm/assets/56465357/e7c4ca88-98c3-4752-b2e1-0fc6958f4a72

