### PR TITLE
fix: resolve sidePanel width issue

### DIFF
--- a/frontend/src/components/SidePanel/index.jsx
+++ b/frontend/src/components/SidePanel/index.jsx
@@ -60,7 +60,7 @@ export default function SidePanel({ config, topContent, bottomContent, fixHeader
   return (
     <Sider
       trigger={<MenuOutlined className="trigger" />}
-      width={window.innerWidth >= screens.md ? '95%' : '400px'}
+      width={screens.md ? '400px' : '95%'}
       collapsed={isSidePanelClose}
       collapsedWidth={'0px'}
       onCollapse={collapsePanel}
@@ -71,6 +71,7 @@ export default function SidePanel({ config, topContent, bottomContent, fixHeader
       }}
       style={{
         left: leftSider,
+        zIndex: '100',
       }}
     >
       <div


### PR DESCRIPTION
This pull request directly addresses issue #333 

By removing the fixed width and introducing a width of '95%', the sidePanel now adapts appropriately to various screen sizes, ensuring content never exceeds the screen width. Additionally, the 'maxWidth' property of 400px guarantees that the panel won't become overly wide on larger screens.

Please review these changes at your convenience. Should you have any questions or further insights, please don't hesitate to reach me out.