### PR TITLE
Fix Customer Phone number validation

### DIFF
--- a/frontend/src/utils/helpers.js
+++ b/frontend/src/utils/helpers.js
@@ -131,7 +131,7 @@ export function formatDatetime(param) {
 /*
   Regex to validate phone number format
 */
-export const validatePhoneNumber = /^(?:[+\d()\-\s]+)$/;
+export const validatePhoneNumber = /^((?:\+[1-9]\d{0,2})|0){0,1}(\s){0,1}(\([1-9]\d{2}\)|[1-9]\d{2})(\s|-|.){0,1}\d{3}(\s|-|.){0,1}\d{4}$/;
 
 /*
  Set object value in html


### PR DESCRIPTION
## Description

Add more validations to phone numbers while adding a new customer.

### Supported valid phone number formats
```
+987 1234567890
+987 123 456 7890
+1 123 456 7890
+12 123 456 7890
0 123 456 7890
0 (123) 456 7890
+12(123) 456 7890
+12 123-456-7890
+12 123.456.7890
+9871234567890
And multiple other combinations.
```
### Invalid phone number formats
```
+0 1234567890 [Country code can't start with 0] 
+12 0234567897 [Phone number can't start with 0] 
+1 123 4567 890, etc. [Phone number can only be divided into 3 parts of digits 3, 3 & 4] 
```

## Related Issues
[Sponsored issue: Able to add phone number in customer of any length #566](https://github.com/idurar/erp-crm/issues/566)

## Steps to Test
> Launch App
> Go to `Customer` from navigation panel
> Click `Add new Customer`
> Enter valid/in-valid phone numbers

## Screenshots (if applicable)
![image](https://github.com/idurar/erp-crm/assets/12026600/3cc28c38-bc70-4a8c-8764-9d775a657bab)


## Checklist

- [x] I have tested these changes
- [ ] I have updated the relevant documentation
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the codebase
- [x] My changes generate no new warnings or errors
- [x] The title of my pull request is clear and descriptive
