### PR TITLE
fix setup app setting

### DIFF
--- a/backend/setup/config/appConfig.json
+++ b/backend/setup/config/appConfig.json
@@ -7,15 +7,15 @@
     "isCoreSetting": true
   },
   {
-    "settingCategory": "app_icon",
-    "settingKey": "app_name",
+    "settingCategory": "app_settings",
+    "settingKey": "app_icon",
     "settingValue": "https://www.idurarapp.com/Theme/idurar-no-code-app/assets/img/idurar-ai-no-code-app-logo.svg",
     "valueType": "image",
     "isCoreSetting": true
   },
   {
-    "settingCategory": "app_logo",
-    "settingKey": "app_name",
+    "settingCategory": "app_settings",
+    "settingKey": "app_logo",
     "settingValue": "https://www.idurarapp.com/Theme/idurar-no-code-app/assets/img/idurar-ai-no-code-app-logo.svg",
     "valueType": "image",
     "isCoreSetting": true


### PR DESCRIPTION
Running node .\setup\setup.js gets this error: 
`MongoBulkWriteError: E11000 duplicate key error collection: idurar.settings index: settingKey_1 dup key: { settingKey: "app_name" }`

So I have updated the settings value in appConfig.json and then it runs the setup correctly.

## Checklist

- [x] I have tested these changes
- [ ] I have updated the relevant documentation
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the codebase
- [x] My changes generate no new warnings or errors
- [x] The title of my pull request is clear and descriptive
