### PR TITLE
bug fix: removed toFixed(2)

### DIFF
--- a/backend/controllers/appControllers/invoiceController/summary.js
+++ b/backend/controllers/appControllers/invoiceController/summary.js
@@ -187,8 +187,8 @@ const summary = async (req, res) => {
     ]);
 
     const finalResult = {
-      total: totalInvoices?.total.toFixed(2),
-      total_undue: unpaid.length > 0 ? unpaid[0].total_amount.toFixed(2) : 0,
+      total: totalInvoices?.total,
+      total_undue: unpaid.length > 0 ? unpaid[0].total_amount : 0,
       type,
       performance: result,
     };

--- a/backend/controllers/appControllers/offerController/summary.js
+++ b/backend/controllers/appControllers/offerController/summary.js
@@ -92,7 +92,7 @@ const summary = async (req, res) => {
       }
     });
 
-    const total = result.reduce((acc, item) => acc + item.total_amount, 0).toFixed(2);
+    const total = result.reduce((acc, item) => acc + item.total_amount, 0);
 
     const finalResult = {
       total,

--- a/backend/controllers/appControllers/quoteController/summary.js
+++ b/backend/controllers/appControllers/quoteController/summary.js
@@ -92,7 +92,7 @@ const summary = async (req, res) => {
       }
     });
 
-    const total = result.reduce((acc, item) => acc + item.total_amount, 0).toFixed(2);
+    const total = result.reduce((acc, item) => acc + item.total_amount, 0);
 
     const finalResult = {
       total,

--- a/backend/controllers/appControllers/supplierOrderController/summary.js
+++ b/backend/controllers/appControllers/supplierOrderController/summary.js
@@ -92,7 +92,7 @@ const summary = async (req, res) => {
       }
     });
 
-    const total = result.reduce((acc, item) => acc + item.total_amount, 0).toFixed(2);
+    const total = result.reduce((acc, item) => acc + item.total_amount, 0);
 
     const finalResult = {
       total,


### PR DESCRIPTION
## Description

When setting EURO as currency, decimal separator as "," and thousand separator as " ' " the summary cards show € 400,00 instead of € 4,00.
Removing toFixed(2) works with both euro configuration and dollar configuration. So the api response's total will be 4 instead of 4.00.
Try it before merge.

## Checklist

- [x] I have tested these changes
- [ ] I have updated the relevant documentation
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the codebase
- [x] My changes generate no new warnings or errors
- [x] The title of my pull request is clear and descriptive
