### PR TITLE
Fix: resolved invoice tax value calculation issue

### DIFF
--- a/frontend/src/components/SelectAsync/index.jsx
+++ b/frontend/src/components/SelectAsync/index.jsx
@@ -14,6 +14,7 @@ export default function SelectAsync({
   redirectLabel = '',
   withRedirect = false,
   urlToRedirect = '/',
+  valueTransformer = null,
 }) {
   const [selectOptions, setOptions] = useState([]);
   const [currentValue, setCurrentValue] = useState(undefined);
@@ -25,7 +26,7 @@ export default function SelectAsync({
   };
   const { result, isLoading: fetchIsLoading, isSuccess } = useFetch(asyncList);
   useEffect(() => {
-    isSuccess && setOptions(result);
+    isSuccess && setOptions(valueTransformer ? valueTransformer(result) : result);
   }, [isSuccess]);
 
   const labels = (optionField) => {

--- a/frontend/src/modules/InvoiceModule/Forms/InvoiceForm.jsx
+++ b/frontend/src/modules/InvoiceModule/Forms/InvoiceForm.jsx
@@ -16,7 +16,8 @@ import useLanguage from '@/locale/useLanguage';
 
 import calculate from '@/utils/calculate';
 import { useSelector } from 'react-redux';
-import SelectAsync from "@/components/SelectAsync";
+import SelectAsync from '@/components/SelectAsync';
+import { taxRateValueTransformer } from '@/utils/helpers';
 
 export default function InvoiceForm({ subTotal = 0, current = null }) {
   const { last_invoice_number } = useSelector(selectFinanceSettings);
@@ -36,9 +37,6 @@ function LoadInvoiceForm({ subTotal = 0, current = null }) {
   const [taxTotal, setTaxTotal] = useState(0);
   const [currentYear, setCurrentYear] = useState(() => new Date().getFullYear());
   const [lastNumber, setLastNumber] = useState(() => last_invoice_number + 1);
-  const handelTaxChange = (value) => {
-    setTaxRate(value/100);
-  };
 
   useEffect(() => {
     if (current) {
@@ -239,15 +237,16 @@ function LoadInvoiceForm({ subTotal = 0, current = null }) {
               ]}
             >
               <SelectAsync
-                  value={taxRate}
-                  onChange={handelTaxChange}
-                  bordered={false}
-                  entity={'taxes'}
-                  outputValue={'taxValue'}
-                  displayLabels={['taxName']}
-                  withRedirect={true}
-                  urlToRedirect="/taxes"
-                  redirectLabel="Add New Tax"
+                value={taxRate}
+                onChange={(v) => setTaxRate(v)}
+                bordered={false}
+                entity={'taxes'}
+                outputValue={'taxValue'}
+                displayLabels={['taxName']}
+                withRedirect={true}
+                urlToRedirect="/taxes"
+                redirectLabel="Add New Tax"
+                valueTransformer={taxRateValueTransformer}
               />
             </Form.Item>
           </Col>

--- a/frontend/src/utils/helpers.js
+++ b/frontend/src/utils/helpers.js
@@ -137,3 +137,19 @@ export function bindValue(obj, parentElement) {
     element.innerHTML = value;
   });
 }
+
+/*
+ * Tax rates are stored on the backend as whole numbers.
+ * For example, 15% is stored as 15 (and not as 0.15) which creates issues on the frontend while calculating tax amount.
+ * This function simply takes in the tax rates and divides them by 100.
+ */
+export const taxRateValueTransformer = (taxes) => {
+  if (taxes) {
+    return taxes.map((tax) => {
+      return {
+        ...tax,
+        taxValue: tax.taxValue / 100,
+      };
+    });
+  }
+};


### PR DESCRIPTION
## Description
I've added a value transformer to the generic SelectAsync component (frontend/src/components/SelectAsync/index.jsx).
It will apply this transformer function to the results, if the function actually exists.
In this case, the transformer function simply divides tax rates by 100.

## Related Issues
https://github.com/idurar/idurar-erp-crm/issues/740

## Steps to Test
1. Go to 'Invoice' section.
2. Click on 'Add New Invoice' button.
3. Fill in all the required details and select a tax.
4. At this point the tax would be displayed correctly.
5. Click on the 'Save' button.
6. The invoice should get created with correct sub-total, tax amount and the grand total.
7. Refresh the page.
8. The invoice should still show correct details.

## Checklist

- [x] I have tested these changes
- [ ] I have updated the relevant documentation
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the codebase
- [x] My changes generate no new warnings or errors
- [x] The title of my pull request is clear and descriptive
