### PR TITLE
Fix: ReadOnly users should not be able to create/update records

### DIFF
--- a/frontend/src/components/CollapseBox/index.jsx
+++ b/frontend/src/components/CollapseBox/index.jsx
@@ -1,9 +1,18 @@
 import React from 'react';
 import { Row, Col } from 'antd';
+import { selectCurrentAdmin } from '@/redux/auth/selectors';
+import { doesAdminHaveEditAccess } from '@/utils/helpers';
+import { useSelector } from 'react-redux';
 
 const CollapseBoxButton = ({ onChange, title }) => {
+  const currentAdmin = useSelector(selectCurrentAdmin);
   return (
-    <div className="collapseBoxHeader" onClick={onChange}>
+    <div
+      className={`collapseBoxHeader ${
+        currentAdmin && !doesAdminHaveEditAccess(currentAdmin) && 'buttonDisabled'
+      }`}
+      onClick={onChange}
+    >
       {title}
     </div>
   );

--- a/frontend/src/modules/AdminCrudModule/index.jsx
+++ b/frontend/src/modules/AdminCrudModule/index.jsx
@@ -28,8 +28,11 @@ import UpdatePassword from './UpdatePassword';
 import { selectCurrentItem } from '@/redux/crud/selectors';
 
 import useLanguage from '@/locale/useLanguage';
+import { doesAdminHaveEditAccess } from '@/utils/helpers';
+import { selectCurrentAdmin } from '@/redux/auth/selectors';
 
 function SidePanelTopContent({ config, formElements }) {
+  const currentAdmin = useSelector(selectCurrentAdmin);
   const translate = useLanguage();
   const { crudContextAction, state } = useCrudContext();
   const { entityDisplayLabels } = config;
@@ -80,6 +83,7 @@ function SidePanelTopContent({ config, formElements }) {
               marginRight: '5px',
               marginLeft: '-5px',
             }}
+            disabled={currentAdmin && !doesAdminHaveEditAccess(currentAdmin)}
           >
             {translate('remove')}
           </Button>
@@ -89,6 +93,7 @@ function SidePanelTopContent({ config, formElements }) {
             icon={<EditOutlined />}
             size="small"
             style={{ float: 'left', marginRight: '5px' }}
+            disabled={currentAdmin && !doesAdminHaveEditAccess(currentAdmin)}
           >
             {translate('edit')}
           </Button>
@@ -98,6 +103,11 @@ function SidePanelTopContent({ config, formElements }) {
             icon={<LockOutlined />}
             size="small"
             style={{ float: 'left', marginRight: '0px' }}
+            disabled={
+              currentAdmin._id === currentItem._id
+                ? false
+                : currentAdmin && !doesAdminHaveEditAccess(currentAdmin)
+            }
           >
             {translate('Update Password')}
           </Button>
@@ -114,6 +124,7 @@ function SidePanelTopContent({ config, formElements }) {
 }
 
 function FixHeaderPanel({ config }) {
+  const currentAdmin = useSelector(selectCurrentAdmin);
   const { crudContextAction } = useCrudContext();
   const { collapsedBox, panel } = crudContextAction;
 
@@ -146,7 +157,12 @@ function FixHeaderPanel({ config }) {
           <SearchItem config={config} />
         </Col>
         <Col className="gutter-row" span={3}>
-          <Button onClick={addNewItem} block={true} icon={<PlusOutlined />}></Button>
+          <Button
+            onClick={addNewItem}
+            block={true}
+            icon={<PlusOutlined />}
+            disabled={currentAdmin && !doesAdminHaveEditAccess(currentAdmin)}
+          ></Button>
         </Col>
       </Row>
     </div>

--- a/frontend/src/modules/CrudModule/CrudModule.jsx
+++ b/frontend/src/modules/CrudModule/CrudModule.jsx
@@ -17,8 +17,11 @@ import { crud } from '@/redux/crud/actions';
 import { useCrudContext } from '@/context/crud';
 
 import { CrudLayout } from '@/layout';
+import { selectCurrentAdmin } from '@/redux/auth/selectors';
+import { doesAdminHaveEditAccess } from '@/utils/helpers';
 
 function SidePanelTopContent({ config, formElements, withUpload }) {
+  const currentAdmin = useSelector(selectCurrentAdmin);
   const translate = useLanguage();
   const { crudContextAction, state } = useCrudContext();
   const { entityDisplayLabels } = config;
@@ -60,6 +63,7 @@ function SidePanelTopContent({ config, formElements, withUpload }) {
             icon={<DeleteOutlined />}
             size="small"
             style={{ float: 'right', marginLeft: '5px' }}
+            disabled={currentAdmin && !doesAdminHaveEditAccess(currentAdmin)}
           >
             {translate('remove')}
           </Button>
@@ -69,6 +73,7 @@ function SidePanelTopContent({ config, formElements, withUpload }) {
             icon={<EditOutlined />}
             size="small"
             style={{ float: 'right', marginLeft: '0px' }}
+            disabled={currentAdmin && !doesAdminHaveEditAccess(currentAdmin)}
           >
             {translate('edit')}
           </Button>
@@ -87,8 +92,8 @@ function SidePanelTopContent({ config, formElements, withUpload }) {
 
 function FixHeaderPanel({ config }) {
   const { crudContextAction } = useCrudContext();
-
   const { collapsedBox } = crudContextAction;
+  const currentAdmin = useSelector(selectCurrentAdmin);
 
   const addNewItem = () => {
     collapsedBox.close();
@@ -104,7 +109,12 @@ function FixHeaderPanel({ config }) {
         <SearchItem config={config} />
       </Col>
       <Col className="gutter-row" span={3}>
-        <Button onClick={addNewItem} block={true} icon={<PlusOutlined />}></Button>
+        <Button
+          onClick={addNewItem}
+          block={true}
+          icon={<PlusOutlined />}
+          disabled={currentAdmin && !doesAdminHaveEditAccess(currentAdmin)}
+        ></Button>
       </Col>
     </Row>
   );

--- a/frontend/src/modules/ErpPanelModule/ReadItem.jsx
+++ b/frontend/src/modules/ErpPanelModule/ReadItem.jsx
@@ -23,6 +23,8 @@ import { DOWNLOAD_BASE_URL } from '@/config/serverApiConfig';
 import { useMoney } from '@/settings';
 import useMail from '@/hooks/useMail';
 import { useNavigate } from 'react-router-dom';
+import { selectCurrentAdmin } from '@/redux/auth/selectors';
+import { doesAdminHaveEditAccess } from '@/utils/helpers';
 
 const Item = ({ item }) => {
   const { moneyFormatter } = useMoney();
@@ -68,6 +70,7 @@ const Item = ({ item }) => {
 };
 
 export default function ReadItem({ config, selectedItem }) {
+  const currentAdmin = useSelector(selectCurrentAdmin);
   const translate = useLanguage();
   const { entity, ENTITY_NAME } = config;
   const dispatch = useDispatch();
@@ -160,6 +163,7 @@ export default function ReadItem({ config, selectedItem }) {
               send(currentErp._id);
             }}
             icon={<MailOutlined />}
+            disabled={currentAdmin && !doesAdminHaveEditAccess(currentAdmin)}
           >
             {translate('Send by Email')}
           </Button>,
@@ -170,6 +174,7 @@ export default function ReadItem({ config, selectedItem }) {
             }}
             icon={<RetweetOutlined />}
             style={{ display: entity === 'quote' ? 'inline-block' : 'none' }}
+            disabled={currentAdmin && !doesAdminHaveEditAccess(currentAdmin)}
           >
             {translate('Convert to Invoice')}
           </Button>,
@@ -187,6 +192,7 @@ export default function ReadItem({ config, selectedItem }) {
             }}
             type="primary"
             icon={<EditOutlined />}
+            disabled={currentAdmin && !doesAdminHaveEditAccess(currentAdmin)}
           >
             {translate('Edit')}
           </Button>,

--- a/frontend/src/modules/InvoiceModule/Forms/InvoiceForm.jsx
+++ b/frontend/src/modules/InvoiceModule/Forms/InvoiceForm.jsx
@@ -16,7 +16,7 @@ import useLanguage from '@/locale/useLanguage';
 
 import calculate from '@/utils/calculate';
 import { useSelector } from 'react-redux';
-import SelectAsync from "@/components/SelectAsync";
+import SelectAsync from '@/components/SelectAsync';
 
 export default function InvoiceForm({ subTotal = 0, current = null }) {
   const { last_invoice_number } = useSelector(selectFinanceSettings);
@@ -37,7 +37,7 @@ function LoadInvoiceForm({ subTotal = 0, current = null }) {
   const [currentYear, setCurrentYear] = useState(() => new Date().getFullYear());
   const [lastNumber, setLastNumber] = useState(() => last_invoice_number + 1);
   const handelTaxChange = (value) => {
-    setTaxRate(value/100);
+    setTaxRate(value / 100);
   };
 
   useEffect(() => {
@@ -124,7 +124,7 @@ function LoadInvoiceForm({ subTotal = 0, current = null }) {
               options={[
                 { value: 'draft', label: translate('Draft') },
                 { value: 'pending', label: translate('Pending') },
-                { value: 'sent', label: translate('Pending') },
+                { value: 'sent', label: translate('Sent') },
               ]}
             ></Select>
           </Form.Item>
@@ -239,16 +239,16 @@ function LoadInvoiceForm({ subTotal = 0, current = null }) {
               ]}
             >
               <SelectAsync
-                  value={taxRate}
-                  onChange={handelTaxChange}
-                  bordered={false}
-                  entity={'taxes'}
-                  outputValue={'taxValue'}
-                  displayLabels={['taxName']}
-                  loadDefault={true}
-                  withRedirect={true}
-                  urlToRedirect="/taxes"
-                  redirectLabel="Add New Tax"
+                value={taxRate}
+                onChange={handelTaxChange}
+                bordered={false}
+                entity={'taxes'}
+                outputValue={'taxValue'}
+                displayLabels={['taxName']}
+                loadDefault={true}
+                withRedirect={true}
+                urlToRedirect="/taxes"
+                redirectLabel="Add New Tax"
               />
             </Form.Item>
           </Col>

--- a/frontend/src/modules/OfferModule/ReadOfferModule/ReadOfferItem.jsx
+++ b/frontend/src/modules/OfferModule/ReadOfferModule/ReadOfferItem.jsx
@@ -22,6 +22,8 @@ import { DOWNLOAD_BASE_URL } from '@/config/serverApiConfig';
 import { useMoney } from '@/settings';
 import useMail from '@/hooks/useMail';
 import { useNavigate } from 'react-router-dom';
+import { selectCurrentAdmin } from '@/redux/auth/selectors';
+import { doesAdminHaveEditAccess } from '@/utils/helpers';
 
 const Item = ({ item }) => {
   const { moneyFormatter } = useMoney();
@@ -67,6 +69,7 @@ const Item = ({ item }) => {
 };
 
 export default function ReadOfferItem({ config, selectedItem }) {
+  const currentAdmin = useSelector(selectCurrentAdmin);
   const translate = useLanguage();
   const { entity, ENTITY_NAME } = config;
   const dispatch = useDispatch();
@@ -157,6 +160,7 @@ export default function ReadOfferItem({ config, selectedItem }) {
               send(currentErp._id);
             }}
             icon={<MailOutlined />}
+            disabled={currentAdmin && !doesAdminHaveEditAccess(currentAdmin)}
           >
             {translate('Send by email')}
           </Button>,
@@ -167,6 +171,7 @@ export default function ReadOfferItem({ config, selectedItem }) {
             }}
             icon={<RetweetOutlined />}
             style={{ display: entity === 'quote' ? 'inline-block' : 'none' }}
+            disabled={currentAdmin && !doesAdminHaveEditAccess(currentAdmin)}
           >
             {translate('Convert to Invoice')}
           </Button>,
@@ -184,6 +189,7 @@ export default function ReadOfferItem({ config, selectedItem }) {
             }}
             type="primary"
             icon={<EditOutlined />}
+            disabled={currentAdmin && !doesAdminHaveEditAccess(currentAdmin)}
           >
             {translate('Edit')}
           </Button>,

--- a/frontend/src/modules/PaymentModule/ReadPaymentModule/components/ReadItem.jsx
+++ b/frontend/src/modules/PaymentModule/ReadPaymentModule/components/ReadItem.jsx
@@ -22,6 +22,8 @@ import { DOWNLOAD_BASE_URL } from '@/config/serverApiConfig';
 import { useMoney } from '@/settings';
 import useMail from '@/hooks/useMail';
 import { useNavigate } from 'react-router-dom';
+import { selectCurrentAdmin } from '@/redux/auth/selectors';
+import { doesAdminHaveEditAccess } from '@/utils/helpers';
 
 const Item = ({ item }) => {
   const { moneyFormatter } = useMoney();
@@ -67,6 +69,7 @@ const Item = ({ item }) => {
 };
 
 export default function ReadItem({ config, selectedItem }) {
+  const currentAdmin = useSelector(selectCurrentAdmin);
   const translate = useLanguage();
   const { entity, ENTITY_NAME } = config;
   const dispatch = useDispatch();
@@ -142,6 +145,7 @@ export default function ReadItem({ config, selectedItem }) {
               send(currentErp._id);
             }}
             icon={<MailOutlined />}
+            disabled={currentAdmin && !doesAdminHaveEditAccess(currentAdmin)}
           >
             {translate('Send by email')}
           </Button>,
@@ -159,6 +163,7 @@ export default function ReadItem({ config, selectedItem }) {
             }}
             type="primary"
             icon={<EditOutlined />}
+            disabled={currentAdmin && !doesAdminHaveEditAccess(currentAdmin)}
           >
             {translate('Edit')}
           </Button>,

--- a/frontend/src/modules/SettingModule/GeneralSettingsModule/forms/GeneralSettingForm.jsx
+++ b/frontend/src/modules/SettingModule/GeneralSettingsModule/forms/GeneralSettingForm.jsx
@@ -2,8 +2,12 @@ import { Form, Input, Select, Tag } from 'antd';
 
 import languages from '@/locale/languages';
 import useLanguage from '@/locale/useLanguage';
+import { useSelector } from 'react-redux';
+import { selectCurrentAdmin } from '@/redux/auth/selectors';
+import { doesAdminHaveEditAccess } from '@/utils/helpers';
 
 export default function GeneralSettingForm() {
+  const currentAdmin = useSelector(selectCurrentAdmin);
   const translate = useLanguage();
   const tagRender = (props) => {
     const { label, closable, onClose } = props;
@@ -36,7 +40,10 @@ export default function GeneralSettingForm() {
           },
         ]}
       >
-        <Input autoComplete="off" />
+        <Input
+          autoComplete="off"
+          disabled={currentAdmin && !doesAdminHaveEditAccess(currentAdmin)}
+        />
       </Form.Item>
       <Form.Item
         label={translate('language')}
@@ -55,6 +62,7 @@ export default function GeneralSettingForm() {
           filterSort={(optionA, optionB) =>
             (optionA?.label ?? '').toLowerCase().startsWith((optionB?.label ?? '').toLowerCase())
           }
+          disabled={currentAdmin && !doesAdminHaveEditAccess(currentAdmin)}
         >
           {languages.map((language) => (
             <Select.Option
@@ -88,6 +96,7 @@ export default function GeneralSettingForm() {
           }}
           tokenSeparators={[',']}
           tagRender={tagRender}
+          disabled={currentAdmin && !doesAdminHaveEditAccess(currentAdmin)}
         ></Select>
       </Form.Item>
     </>

--- a/frontend/src/modules/SettingModule/components/UpdateSettingForm/index.jsx
+++ b/frontend/src/modules/SettingModule/components/UpdateSettingForm/index.jsx
@@ -7,8 +7,11 @@ import { selectSettings } from '@/redux/settings/selectors';
 
 import { Button, Form } from 'antd';
 import Loading from '@/components/Loading';
+import { selectCurrentAdmin } from '@/redux/auth/selectors';
+import { doesAdminHaveEditAccess } from '@/utils/helpers';
 
 export default function UpdateSettingForm({ config, children }) {
+  const currentAdmin = useSelector(selectCurrentAdmin);
   let { entity, settingsCategory } = config;
   const dispatch = useDispatch();
   const { result, isLoading, isSuccess } = useSelector(selectSettings);
@@ -67,7 +70,11 @@ export default function UpdateSettingForm({ config, children }) {
               paddingRight: '5px',
             }}
           >
-            <Button type="primary" htmlType="submit">
+            <Button
+              type="primary"
+              htmlType="submit"
+              disabled={currentAdmin && !doesAdminHaveEditAccess(currentAdmin)}
+            >
               Save
             </Button>
           </Form.Item>

--- a/frontend/src/modules/SettingModule/components/UploadSettingForm/index.jsx
+++ b/frontend/src/modules/SettingModule/components/UploadSettingForm/index.jsx
@@ -7,8 +7,11 @@ import { selectSettings } from '@/redux/settings/selectors';
 
 import { Button, Form } from 'antd';
 import Loading from '@/components/Loading';
+import { selectCurrentAdmin } from '@/redux/auth/selectors';
+import { doesAdminHaveEditAccess } from '@/utils/helpers';
 
 export default function UploadSettingForm({ config, settingKey, children }) {
+  const currentAdmin = useSelector(selectCurrentAdmin);
   let { entity, settingsCategory } = config;
   const dispatch = useDispatch();
   const { result, isLoading, isSuccess } = useSelector(selectSettings);
@@ -48,7 +51,11 @@ export default function UploadSettingForm({ config, settingKey, children }) {
               paddingRight: '5px',
             }}
           >
-            <Button type="primary" htmlType="submit">
+            <Button
+              type="primary"
+              htmlType="submit"
+              disabled={currentAdmin && !doesAdminHaveEditAccess(currentAdmin)}
+            >
               Save
             </Button>
           </Form.Item>

--- a/frontend/src/style/partials/collapseBox.css
+++ b/frontend/src/style/partials/collapseBox.css
@@ -54,3 +54,8 @@
   background-color: hsla(0, 0%, 100%, 0.8);
   z-index: 9;
 }
+
+.collapseBox .buttonDisabled {
+  pointer-events: none;
+  opacity: 0.4;
+}

--- a/frontend/src/utils/helpers.js
+++ b/frontend/src/utils/helpers.js
@@ -137,3 +137,7 @@ export function bindValue(obj, parentElement) {
     element.innerHTML = value;
   });
 }
+
+export function doesAdminHaveEditAccess(admin) {
+  return admin && admin.role !== 'readOnly';
+}


### PR DESCRIPTION
## Description
The edit, add, delete, update password buttons on the frontend will now be disabled for admins with `readOnly` access.

## Related Issues
https://github.com/idurar/idurar-erp-crm/issues/793

## Steps to Test
1. Create a readOnly admin user by navigating to the admin section
2. Login using the readOnly user that you just created. (You can also use any existing readOnly user as well)
3. Verify if you're able to create records like offers, leads, etc. - you should not be able to do so.

## Checklist
- [x] I have tested these changes
- [ ] I have updated the relevant documentation
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the codebase
- [x] My changes generate no new warnings or errors
- [x] The title of my pull request is clear and descriptive


## Additional Info
There is also this minor label issue that I've fixed on `frontend/src/modules/InvoiceModule/Forms/InvoiceForm.jsx`.
The label should have been 'Sent' but it was 'Pending' instead.