### PR TITLE
fix: Change Pending to Sent Label

### DIFF
--- a/frontend/src/modules/InvoiceModule/Forms/InvoiceForm.jsx
+++ b/frontend/src/modules/InvoiceModule/Forms/InvoiceForm.jsx
@@ -124,7 +124,7 @@ function LoadInvoiceForm({ subTotal = 0, current = null }) {
               options={[
                 { value: 'draft', label: translate('Draft') },
                 { value: 'pending', label: translate('Pending') },
-                { value: 'sent', label: translate('Pending') },
+                { value: 'sent', label: translate('Sent') },
               ]}
             ></Select>
           </Form.Item>


### PR DESCRIPTION
## Description

While creating new Invoice, the Status field have 3 values (Draft, Pending, and Pending). "Pending" is coming two times. I have checked the code, the 'value' on Select component is 'Sent' but 'label' is set as 'Pending' which is wrong.

## Related Issues

#797 

## Steps to Test

1. Go to 'Invoice' tab
2. Click on 'Add new Invoice'
3. Expand Status field
4. Notice that Status field is showing three values with no repetition

## Screenshots (if applicable)

Before:
![image](https://github.com/idurar/idurar-erp-crm/assets/20161529/416d3bd2-37a7-4685-9124-55e15fa159b4)
After:
![image](https://github.com/idurar/idurar-erp-crm/assets/20161529/f0b0a59a-3075-4faa-ab82-657a0d97c461)


## Checklist

- [x] I have tested these changes
- [ ] I have updated the relevant documentation
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the codebase
- [x] My changes generate no new warnings or errors
- [x] The title of my pull request is clear and descriptive
