### PR TITLE
Remove the isRTL flag from the languages object for code simplicity

### DIFF
--- a/frontend/src/locale/languages.js
+++ b/frontend/src/locale/languages.js
@@ -1,5 +1,5 @@
 const languages = [
-  { icon: '🇩🇿 ', label: 'Arabic', value: 'ar_eg', isRtl: true },
+  { icon: '🇩🇿 ', label: 'Arabic', value: 'ar_eg' },
   { icon: '🇧🇩 ', label: 'Bengali', value: 'bn_bd' },
   { icon: '🇧🇬 ', label: 'Bulgarian', value: 'bg_bg' },
   { icon: '🇪🇦 ', label: 'Catalonian', value: 'ca_es' },
@@ -25,7 +25,7 @@ const languages = [
   { icon: '🇲🇰 ', label: 'Macedonian', value: 'mk_mk' },
   { icon: '🇲🇾 ', label: 'Malay', value: 'ms_my' },
   { icon: '🇳🇴 ', label: 'Norwegian', value: 'nb_no' },
-  { icon: '🇮🇷 ', label: 'Persian', value: 'fa_ir', isRtl: true },
+  { icon: '🇮🇷 ', label: 'Persian', value: 'fa_ir' },
   { icon: '🇵🇱 ', label: 'Polish', value: 'pl_pl' },
   { icon: '🇧🇷 ', label: 'Portuguese Brazil', value: 'pt_br' },
   { icon: '🇵🇹 ', label: 'Portuguese Portugal', value: 'pt_pt' },
@@ -39,7 +39,7 @@ const languages = [
   { icon: '🇹🇭 ', label: 'Thai', value: 'th_th' },
   { icon: '🇹🇷 ', label: 'Turkish', value: 'tr_tr' },
   { icon: '🇺🇦 ', label: 'Ukrainian', value: 'uk_ua' },
-  { icon: '🇵🇰 ', label: 'Urdu', value: 'ur_pk', isRtl: true },
+  { icon: '🇵🇰 ', label: 'Urdu', value: 'ur_pk' },
   { icon: '🇻🇳 ', label: 'Vietnamese', value: 'vi_vn' },
 ];
 


### PR DESCRIPTION
## Description

Remove the isRTL flag from the languages object for code simplicity and understandibility. As you also mention in the YouTube video for adding the languages.

## Related Issues


## Steps to Test



## Screenshots (if applicable)



## Checklist

- [X] I have tested these changes
- [ ] I have updated the relevant documentation
- [ ] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the codebase
- [ ] My changes generate no new warnings or errors
- [X] The title of my pull request is clear and descriptive
