### PR TITLE
fix: back button on Read email template

### DIFF
--- a/frontend/src/modules/EmailModule/ReadEmailModule/components/ReadItem.jsx
+++ b/frontend/src/modules/EmailModule/ReadEmailModule/components/ReadItem.jsx
@@ -52,7 +52,7 @@ export default function ReadItem({ config, selectedItem }) {
       <PageHeader
         onBack={() => {
           readPanel.close();
-          history.goBack();
+          navigate(`/${entity.toLowerCase()}`);//navigate to previous page
         }}
         title={`${ENTITY_NAME} # ${currentErp?.emailName}`}
         ghost={false}


### PR DESCRIPTION
## Description

For going back to the email templates list page, history.goBack() was used but history object was never defined. I replaced history.goBack() with navigate(`/${entity.toLowerCase()}`); which is working fine. This approach is also used while pressing Close button.

## Related Issues

[#802 ](https://github.com/idurar/idurar-erp-crm/issues/802)

## Steps to Test

1. Go to 'Settings'
2. Click on 'Email Templates'
3. Click on Dropdown in front of any email template > Show
4. Click on back button
5. Notice that, user can go back which was not working previously.

## Screenshots (if applicable)

![image](https://github.com/idurar/idurar-erp-crm/assets/20161529/ea2cb79f-aec0-41e1-910e-636153e8218e)

## Checklist

- [x] I have tested these changes
- [ ] I have updated the relevant documentation
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the codebase
- [x] My changes generate no new warnings or errors
- [x] The title of my pull request is clear and descriptive
