### PR TITLE
fix: .env.local environments variable not loading

### DIFF
--- a/backend/setup/reset.js
+++ b/backend/setup/reset.js
@@ -1,5 +1,5 @@
 require('dotenv').config({ path: __dirname + '/../.env' });
-
+require('dotenv').config({ path: __dirname + '/../.env.local' });
 const mongoose = require('mongoose');
 mongoose.connect(process.env.DATABASE);
 mongoose.Promise = global.Promise; // Tell Mongoose to use ES6 promises

--- a/backend/setup/setup.js
+++ b/backend/setup/setup.js
@@ -1,5 +1,5 @@
 require('dotenv').config({ path: __dirname + '/../.env' });
-
+require('dotenv').config({ path: __dirname + '/../.env.local' });
 const mongoose = require('mongoose');
 mongoose.connect(process.env.DATABASE);
 mongoose.Promise = global.Promise; // Tell Mongoose to use ES6 promises


### PR DESCRIPTION
## Description

Making environments variable to load from .env.local in backend/setup/setup.js and backend/setup/reset.js .

## Related Issues

#819 

## Steps to Test
1. Create .env.local file in beside .env and copy environments variable from .env to .env.local edit appropriate variable like DATABASE for mongoose uri connection.
![Screenshot from 2023-11-18 09-55-10](https://github.com/idurar/idurar-erp-crm/assets/54697799/becd3555-ccfc-4382-86d4-16aa6df27ed9)
2. Run npm run setup and npm run reset to see whether data in MongoDB cluster is created and removed respectively.

## Screenshots (if applicable)

If your changes include visual updates, it would be helpful to provide screenshots of the before and after.
Before screen shots there is issue #819 
After screen shots

setup.js 
![Screenshot from 2023-11-18 10-41-49](https://github.com/idurar/idurar-erp-crm/assets/54697799/98e3f1b4-025d-4673-adc0-908649267510)

reset.js
![Screenshot from 2023-11-18 10-41-31](https://github.com/idurar/idurar-erp-crm/assets/54697799/eb0cc9e0-809f-467f-9947-63bc2861d5d1)
 


## Checklist

- [x] I have tested these changes
- [ ] I have updated the relevant documentation
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the codebase
- [x] My changes generate no new warnings or errors
- [x] The title of my pull request is clear and descriptive
