### PR TITLE
fix: wrong dotenv config path in backend/src/setup

### DIFF
--- a/backend/src/setup/reset.js
+++ b/backend/src/setup/reset.js
@@ -1,5 +1,5 @@
-require('dotenv').config({ path: __dirname + '/../.env' });
-require('dotenv').config({ path: __dirname + '/../.env.local' });
+require('dotenv').config({ path: __dirname + '/../../.env' });
+require('dotenv').config({ path: __dirname + '/../../.env.local' });
 
 const mongoose = require('mongoose');
 mongoose.connect(process.env.DATABASE);

--- a/backend/src/setup/setup.js
+++ b/backend/src/setup/setup.js
@@ -1,5 +1,5 @@
-require('dotenv').config({ path: __dirname + '/../.env' });
-require('dotenv').config({ path: __dirname + '/../.env.local' });
+require('dotenv').config({ path: __dirname + '/../../.env' });
+require('dotenv').config({ path: __dirname + '/../../.env.local' });
 
 const mongoose = require('mongoose');
 mongoose.connect(process.env.DATABASE);


### PR DESCRIPTION
## Description

Wrong dotenv config path for env and env.local in backend/src/setup/setup.js and backend/src/setup/reset.js.
 
## Related Issues

#823 

## Steps to Test
1. Create .env.local file in beside .env and copy environments variable from .env to .env.local edit appropriate variable like DATABASE for mongoose uri connection.
2. Run npm run setup and npm run reset to see whether data in MongoDB cluster is created and removed respectively.

## Screenshots (if applicable)

If your changes include visual updates, it would be helpful to provide screenshots of the before and after.

before

reset.js 
![Screenshot from 2023-11-18 11-54-57](https://github.com/idurar/idurar-erp-crm/assets/54697799/00bbaca9-fda4-415b-89d3-9b89e9369504)

setup.js
![Screenshot from 2023-11-18 11-54-49](https://github.com/idurar/idurar-erp-crm/assets/54697799/8d82937c-7913-41bc-8056-a94a93c12470)


after
setup.js
![Screenshot from 2023-11-18 11-53-54](https://github.com/idurar/idurar-erp-crm/assets/54697799/65ca1380-bc29-4184-ab63-cb5bb2102bbc)

reset.js
![Screenshot from 2023-11-18 11-53-40](https://github.com/idurar/idurar-erp-crm/assets/54697799/c15a2947-423a-4e33-97c0-8325b7e94dd1)
 
 

## Checklist

- [x] I have tested these changes
- [ ] I have updated the relevant documentation
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the codebase
- [x] My changes generate no new warnings or errors
- [x] The title of my pull request is clear and descriptive
