### PR TITLE
add taxes to Chinese Localization

### DIFF
--- a/frontend/src/locale/translation/zh_cn.js
+++ b/frontend/src/locale/translation/zh_cn.js
@@ -319,13 +319,15 @@ const lang = {
   active_customer: '活跃客户',
   customer_preview: '客户预览',
   new_customer_this_month: '本月新增客户',
-
   already_have_account_login: '已经拥有帐户 登录',
   forgot_password: '忘记密码',
   log_in: '登录',
   or: '或者',
   sign_in: '登录',
   sign_up: '注册',
+  taxes: '稅收',
+  taxes_list: '稅項清單',
+  add_new_tax: '新增稅',
 };
 
 export default lang;


### PR DESCRIPTION
## Description

Taxes Keys Are Not Set In Chinese Localization Json File

## Related Issues

#837

## Steps to Test

I has just not Displaying In English Language

## Screenshots (if applicable)

If your changes include visual updates, it would be helpful to provide screenshots of the before and after.

## Checklist

- [x] I have tested these changes
- [ ] I have updated the relevant documentation
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the codebase
- [ ] My changes generate no new warnings or errors
- [x] The title of my pull request is clear and descriptive
