### PR TITLE
Issues/show top ten records search

### DIFF
--- a/backend/src/controllers/middlewaresControllers/createCRUDController/search.js
+++ b/backend/src/controllers/middlewaresControllers/createCRUDController/search.js
@@ -1,6 +1,6 @@
 const search = async (Model, req, res) => {
   // console.log(req.query.fields)
-  if (req.query.q === undefined || req.query.q.trim() === '') {
+  if (req.query.q === undefined) {
     return res
       .status(202)
       .json({

--- a/frontend/src/components/AutoCompleteAsync/index.jsx
+++ b/frontend/src/components/AutoCompleteAsync/index.jsx
@@ -44,7 +44,7 @@ export default function AutoCompleteAsync({
   };
 
   useEffect(() => {
-    if (debouncedValue != '') {
+    if (debouncedValue != undefined) {
       const options = {
         q: debouncedValue,
         fields: searchFields,
@@ -58,7 +58,7 @@ export default function AutoCompleteAsync({
   }, [debouncedValue]);
 
   const onSearch = (searchText) => {
-    if (searchText && searchText != '') {
+    if (searchText || searchText === '') {
       isSearching.current = true;
       setSearching(true);
       setOptions([]);
@@ -76,12 +76,19 @@ export default function AutoCompleteAsync({
         setCurrentValue(undefined);
         setOptions([]);
       }
+    } else if (valToSearch === '' && isSuccess) {
+      //As isSearching.current remains false when valToSearch
+      //is blank, we need to update options with result containing
+      //top 10 rows
+      setOptions(result);
     }
   }, [isSuccess, result]);
   useEffect(() => {
     // this for update Form , it's for setField
     if (value && isUpdating.current) {
-      if (!isSearching.current) {
+      //This is causing issue when valToSearch is blank
+      // because it is populating options array with value i.e id which should not be the case
+      if (!isSearching.current && valToSearch !== '') {
         setOptions([value]);
       }
       setCurrentValue(value[outputValue] || value); // set nested value or value
@@ -107,7 +114,9 @@ export default function AutoCompleteAsync({
         }
       }}
       onClear={() => {
-        setOptions([]);
+        //As we are showing top 10 records after clearing field,
+        //hence options don't need to be empty after clear
+        //setOptions([]);
         setCurrentValue(undefined);
         setSearching(false);
       }}


### PR DESCRIPTION
## Description

Made changes in two files:

Search.js
Allowing to construct query when entered text is blank rather than throwing error

AutoCompleteAsync.tsx
Changes to hit api and show top 10 records when text is blank

## Related Issues

#832 

## Steps to Test

1. Click on Invoice
2. New Invoice
3. Click on Client field
4. Previously you were seeing no records but after this PR, you will see 10 records existing in database
5. This solution is generic as per the requirement and it will work on every search field

## Screenshots (if applicable)

New Invoice before:
![image](https://github.com/idurar/idurar-erp-crm/assets/20161529/c0f8ba9a-7c4e-4145-930d-ae2d934194ac)

New Invoice after:
![image](https://github.com/idurar/idurar-erp-crm/assets/20161529/adb73846-5b72-49c7-9748-4e376cc08b14)

New Offer:
![image](https://github.com/idurar/idurar-erp-crm/assets/20161529/a703f922-c1cc-4184-8148-20759ffb8db5)

Note: You can see limited records in invoice page in screenshot because there is a scrollbar

## Checklist

- [x] I have tested these changes
- [ ] I have updated the relevant documentation
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the codebase
- [x] My changes generate no new warnings or errors
- [x] The title of my pull request is clear and descriptive
