### PR TITLE
Fix: display of the tag when the value is zero #857

### DIFF
--- a/frontend/src/modules/DashboardModule/index.jsx
+++ b/frontend/src/modules/DashboardModule/index.jsx
@@ -110,7 +110,7 @@ export default function DashboardModule() {
         }
         prefix={translate('This month')}
         isLoading={isLoading}
-        tagContent={result?.total && moneyFormatter({ amount: result?.total })}
+        tagContent={moneyFormatter({ amount: result?.total })}
       />
     );
   });
@@ -147,9 +147,7 @@ export default function DashboardModule() {
           tagColor={'red'}
           prefix={translate('Not Paid')}
           isLoading={invoiceLoading}
-          tagContent={
-            invoiceResult?.total_undue && moneyFormatter({ amount: invoiceResult?.total_undue })
-          }
+          tagContent={moneyFormatter({ amount: invoiceResult?.total_undue })}
         />
       </Row>
       <div className="space30"></div>


### PR DESCRIPTION
## Description

The changes applied in this pull request standardize the display of tags whether the value is zero or not.

So, before the pull request, the null tags looked like this:
![image](https://github.com/idurar/idurar-erp-crm/assets/85080566/3fd7babe-d41c-403f-ab7c-f706ec7fd110)

Now they look like this:
![image](https://github.com/idurar/idurar-erp-crm/assets/85080566/19d711b5-bed7-4c56-802f-a89eb9375d84)

Technical Explanation : 

Given that the moneyFormatter() function defines a default argument equal to 0 if the latter is not defined, it is not useful to check the state of "result?.total" before calling the function.

## Related Issues

This PR is supposed to fix the issue : #857 

## Steps to Test

To test the solution:

1) go to the dashboard
2) place your cursor on one of the prices (null or non-null) of the summary thumbnails.
3) Tags should all follow the same “currency price” format (ex: $ 0.00; $ 3,000.00)

## Screenshots (if applicable)

![image](https://github.com/idurar/idurar-erp-crm/assets/85080566/24f02b3e-5d82-46d8-83bd-fc6769fc910d)
![image](https://github.com/idurar/idurar-erp-crm/assets/85080566/bf1e4c80-c8c4-4b02-a82a-2e7f560a2610)

## Checklist

- [x] I have tested these changes
- [ ] I have updated the relevant documentation
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the codebase
- [x] My changes generate no new warnings or errors
- [x] The title of my pull request is clear and descriptive
