### PR TITLE
feat: add antd tabs to the dashboard preview card for smaller screen …

### DIFF
--- a/frontend/src/modules/DashboardModule/index.jsx
+++ b/frontend/src/modules/DashboardModule/index.jsx
@@ -1,4 +1,4 @@
-import { Tag, Row, Col } from 'antd';
+import { Tag, Row, Col, Tabs } from 'antd';
 import useLanguage from '@/locale/useLanguage';
 
 import { useMoney } from '@/settings';
@@ -115,6 +115,37 @@ export default function DashboardModule() {
     );
   });
 
+  const statisticCardsTabs = () => {
+    const previewCardMap = entityData.map((data, index) => {
+      const { result, entity, isLoading, title } = data;
+
+      if (entity === 'payment') return null;
+      return {
+        key: index.toString(),
+        label: title,
+        children: (
+          <PreviewCard
+            key={index}
+            title={title}
+            isLoading={isLoading}
+            entity={entity}
+            statistics={
+              !isLoading &&
+              result?.performance?.map((item) => ({
+                tag: item?.status,
+                color: 'blue',
+                value: item?.percentage,
+              }))
+            }
+          />
+        ),
+      };
+    });
+    return (
+      <Tabs defaultActiveKey="1" items={previewCardMap} className="w-full" tabPosition="top" />
+    );
+  };
+
   const statisticCards = entityData.map((data, index) => {
     const { result, entity, isLoading, title } = data;
 
@@ -152,10 +183,29 @@ export default function DashboardModule() {
       </Row>
       <div className="space30"></div>
       <Row gutter={[32, 32]}>
-        <Col className="gutter-row w-full" sm={{ span: 24 }} md={{ span: 24 }} lg={{ span: 18 }}>
+        <Col
+          className="gutter-row w-full"
+          xs={{ span: 0 }}
+          sm={{ span: 0 }}
+          md={{ span: 0 }}
+          lg={{ span: 18 }}
+        >
           <div className="whiteBox shadow" style={{ height: 458 }}>
             <Row className="pad20" gutter={[0, 0]}>
               {statisticCards}
+            </Row>
+          </div>
+        </Col>
+        <Col
+          className="gutter-row w-full"
+          xs={{ span: 24 }}
+          sm={{ span: 24 }}
+          md={{ span: 24 }}
+          lg={{ span: 0 }}
+        >
+          <div className="whiteBox shadow" style={{ height: 458 }}>
+            <Row className="pad20" gutter={[0, 0]}>
+              {statisticCardsTabs()}
             </Row>
           </div>
         </Col>


### PR DESCRIPTION


## Description

Have added Ant Design tabs for the Statistic Preview card, on the dashboard home page. **Will only be visible from medium to small screen size.** Fixes any alignment issues and visibility issues in that particular card on screen size change.

## Related Issues

https://github.com/idurar/idurar-erp-crm/issues/876

## Steps to Test

1. Go to the dashboard homepage.
2. Change the screen size to observe the feature.

## Screenshots (if applicable)

![3-full](https://github.com/idurar/idurar-erp-crm/assets/27354444/446a01c9-ae95-4469-add4-2413607dd645)

![1](https://github.com/idurar/idurar-erp-crm/assets/27354444/d80025c2-28aa-4d53-b02c-7badcb44ded0)

![2](https://github.com/idurar/idurar-erp-crm/assets/27354444/a62c988d-9c8f-4fef-97bf-dceb5058a8e4)

![6](https://github.com/idurar/idurar-erp-crm/assets/27354444/26d88835-b825-4f00-a9ac-535a28eee0b9)







## Checklist

- [X] I have tested these changes
- [ ] I have updated the relevant documentation
- [ ] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the codebase
- [X] My changes generate no new warnings or errors
- [X] The title of my pull request is clear and descriptive
