### PR TITLE
add translation of payment status and status in show feature

### DIFF
--- a/frontend/src/modules/ErpPanelModule/ReadItem.jsx
+++ b/frontend/src/modules/ErpPanelModule/ReadItem.jsx
@@ -131,7 +131,14 @@ export default function ReadItem({ config, selectedItem }) {
         }}
         title={`${ENTITY_NAME} # ${currentErp.number}/${currentErp.year || ''}`}
         ghost={false}
-        tags={<Tag color="volcano">{currentErp.paymentStatus || currentErp.status}</Tag>}
+        tags={
+          <Tag color="volcano">{
+            (currentErp.paymentStatus && translate(currentErp.paymentStatus)) 
+            || 
+            (currentErp.status && translate(currentErp.status))
+            }
+          </Tag>
+        }
         // subTitle="This is cuurent erp page"
         extra={[
           <Button


### PR DESCRIPTION
## Description

I added the translation to the payment status and status in the show feature.

## Related Issues

#881

## Steps to Test

1. Go to the invoice/offer/quote list
2. Click on the 3 dots of one of the items
3. Click on "Show"
4. change your language 
5. See that the status is now displayed in the language you chose and not in english.

## Screenshots (if applicable)

![image](https://github.com/idurar/idurar-erp-crm/assets/85080566/9297f2fa-1806-4122-a5c2-8d7a3198ba97)

![image](https://github.com/idurar/idurar-erp-crm/assets/85080566/2bc33ef4-3bf6-4bb5-9987-a9f743bb6c9c)

## Checklist

- [x] I have tested these changes
- [ ] I have updated the relevant documentation
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the codebase
- [x] My changes generate no new warnings or errors
- [x] The title of my pull request is clear and descriptive
