### PR TITLE
fixed translation issue in RecordPayment (status and payment status)

### DIFF
--- a/frontend/src/modules/InvoiceModule/RecordPaymentModule/components/Payment.jsx
+++ b/frontend/src/modules/InvoiceModule/RecordPaymentModule/components/Payment.jsx
@@ -61,7 +61,11 @@ export default function Payment({ config, currentItem }) {
               currentErp.year || ''
             }`}
             ghost={false}
-            tags={<Tag color="volcano">{currentErp.status}</Tag>}
+            tags={
+              <Tag color="volcano">
+                {currentErp.status && translate(currentErp.status)}
+              </Tag>
+            }
             // subTitle="This is cuurent erp page"
             extra={[
               <Button
@@ -102,7 +106,7 @@ export default function Payment({ config, currentItem }) {
             <Descriptions.Item label={translate('phone')}>{client.phone}</Descriptions.Item>
             <Divider dashed />
             <Descriptions.Item label={translate('payment status')}>
-              {currentErp.paymentStatus}
+              {currentErp.paymentStatus && translate(currentErp.paymentStatus)}
             </Descriptions.Item>
             <Descriptions.Item label={translate('sub total')}>
               {money.amountFormatter({ amount: currentErp.subTotal })}


### PR DESCRIPTION
## Description

I added the translation to the payment status and status in the record payment.

## Related Issues

#881 

## Steps to Test

1. Go to invoice
2. Select an item
3. Click on the 3 dots
4. Choose Record Payment
5. Change the language into one different than english
6. See that the status of the invoice as well as the payment status are in the chosen language

## Screenshots (if applicable)

![image](https://github.com/idurar/idurar-erp-crm/assets/85080566/15f57aa3-b83e-460d-9c97-12529d649af2)

## Checklist

- [x] I have tested these changes
- [ ] I have updated the relevant documentation
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the codebase
- [x] My changes generate no new warnings or errors
- [x] The title of my pull request is clear and descriptive
