### PR TITLE
fix: avoid overriding of translations data from previous state

### DIFF
--- a/frontend/src/redux/translate/reducer.js
+++ b/frontend/src/redux/translate/reducer.js
@@ -33,7 +33,7 @@ const translateReducer = (state = INITIAL_STATE, action) => {
 
     case actionTypes.REQUEST_SUCCESS:
       return {
-        result: { ...state.result, ...payload },
+        result: payload,
         langCode: langCode.toLowerCase(),
         langDirection: isRtl ? 'rtl' : 'ltr',
         isLoading: false,


### PR DESCRIPTION
Avoid overriding previous state translations data over new translations. 

File
```
frontend/src/redux/translate/reducer.js

```

Please provide a brief description of the changes or additions made in this pull request.


`      return {
       result: { ...state.result, ...payload },
         langCode: langCode.toLowerCase(),
         langDirection: isRtl ? 'rtl' : 'ltr',
         isLoading: false
}
`

This would make the translations data in the result dirty. 

Unless if there was a specific use case, due to which this is written like this {` ...state.result, ...payload }`, we should avoid destructuring of new translations over previous state translations. 

Because, when there are keys that are present in Hindi translation but are not present in English translation file, it would retain such keys and its values when we change locale from Hindi to English due to this destructuring `{ ...state.result, ...payload }`


## Related Issues

If this pull request is related to any issue(s), please list them here.
https://github.com/idurar/idurar-erp-crm/issues/900

## Steps to Test
- Navigate to /admin
- Check selected locale
- Click on Add new Admin, and check strings for Role dropdown
- 
![image](https://github.com/idurar/idurar-erp-crm/assets/15543311/7c47901f-6db8-484c-bf05-9decbe0cc90e)

- Change locale to Hindi, and then again click on Add new Admin and verify Role dropdown
- 
![image](https://github.com/idurar/idurar-erp-crm/assets/15543311/20d64a1a-4cd6-4648-ac8f-1356531ef7a0)

- Now, go back and change locale to English and check the Role dropdown again
- Ideally all the strings should have translated back to English. But some strings are still in Hindi
- 
![image](https://github.com/idurar/idurar-erp-crm/assets/15543311/b7c117d4-c6b4-44d5-aee1-26282e6d175c)


This is basically because, there are some strings missing in then en_us translation file, due to which  the logic {` ...state.result, ...payload }` retained previous states translations. 

Although it is suggested to maintain translations data similar across locale, it is also a better practice to avoid merging previous translation object and new translation object. 

Provide steps on how to test the changes introduced in this pull request.
- Follow the same steps above. 

## Screenshots (if applicable)

If your changes include visual updates, it would be helpful to provide screenshots of the before and after.

## Checklist

- [x] I have tested these changes
- [] I have updated the relevant documentation
- [] I have commented my code, particularly in hard-to-understand areas
- [] I have made corresponding changes to the codebase
- [x] My changes generate no new warnings or errors
- [x] The title of my pull request is clear and descriptive
