### PR TITLE
feat: Remove Refresh button text , use icon only

### DIFF
--- a/frontend/src/components/DataTable/DataTable.jsx
+++ b/frontend/src/components/DataTable/DataTable.jsx
@@ -1,6 +1,12 @@
 import { useCallback, useEffect } from 'react';
 
-import { EyeOutlined, EditOutlined, DeleteOutlined, EllipsisOutlined } from '@ant-design/icons';
+import {
+  EyeOutlined,
+  EditOutlined,
+  DeleteOutlined,
+  EllipsisOutlined,
+  RedoOutlined,
+} from '@ant-design/icons';
 import { Dropdown, Table, Button } from 'antd';
 import { PageHeader } from '@ant-design/pro-layout';
 
@@ -168,9 +174,8 @@ export default function DataTable({ config, extra = [] }) {
         title={DATATABLE_TITLE}
         ghost={false}
         extra={[
-          <Button onClick={handelDataTableLoad} key={`${uniqueId()}`}>
-            {translate('Refresh')}
-          </Button>,
+          <Button onClick={handelDataTableLoad} key={`${uniqueId()}`} icon={<RedoOutlined />} />,
+
           <AddNewItem key={`${uniqueId()}`} config={config} />,
         ]}
         style={{

--- a/frontend/src/modules/ErpPanelModule/DataTable.jsx
+++ b/frontend/src/modules/ErpPanelModule/DataTable.jsx
@@ -171,9 +171,8 @@ export default function DataTable({ config, extra = [] }) {
         title={DATATABLE_TITLE}
         ghost={true}
         extra={[
-          <Button onClick={handelDataTableLoad} key={`${uniqueId()}`} icon={<RedoOutlined />}>
-            {translate('Refresh')}
-          </Button>,
+          <Button onClick={handelDataTableLoad} key={`${uniqueId()}`} icon={<RedoOutlined />} />,
+
           !disableAdd && <AddNewItem config={config} key={`${uniqueId()}`} />,
         ]}
         style={{


### PR DESCRIPTION
closes: #923 
## Description
Removing the refresh text, and using the refresh icon only.
## Related Issues

If this pull request is related to any issue(s), please list them here.

## Steps to Test

Provide steps on how to test the changes introduced in this pull request.


## Screenshots (if applicable)
![DB139D84-233C-414D-BBBF-505FB1E57711_1_201_a](https://github.com/idurar/idurar-erp-crm/assets/113882904/3cc59f09-e0ce-41f5-b3e0-ffae7837b301)

If your changes include visual updates, it would be helpful to provide screenshots of the before and after.

## Checklist

- [ ] I have tested these changes
- [ ] I have updated the relevant documentation
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the codebase
- [ ] My changes generate no new warnings or errors
- [ ] The title of my pull request is clear and descriptive
