### PR TITLE
Better icon for Admin Update Password

### DIFF
--- a/frontend/src/modules/AdminCrudModule/AdminDataTable.jsx
+++ b/frontend/src/modules/AdminCrudModule/AdminDataTable.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { EyeOutlined } from '@ant-design/icons';
+import { UnlockOutlined } from '@ant-design/icons';
 import DataTable from '@/components/DataTable/DataTable';
 
 import useLanguage from '@/locale/useLanguage';
@@ -15,7 +15,7 @@ export default function AdminCrudModule({ config }) {
         {
           label: translate('Update Password'),
           key: 'updatePassword',
-          icon: <EyeOutlined />,
+          icon: <UnlockOutlined/>,
         },
       ]}
     />


### PR DESCRIPTION
## Description

I noticed that both the "Show" and "Update Password" actions in the Admin List table were using the same icon, so i changed the Update Password's icon to a more suitable one using Ant Design.

## Screenshots (if applicable)

_This is The Before:_
![Screenshot (409)](https://github.com/idurar/idurar-erp-crm/assets/133030569/0c662833-9eba-4e6b-af7d-e7b295b8d1e5)

_This is the After:_
![Screenshot (411)](https://github.com/idurar/idurar-erp-crm/assets/133030569/7851cbd1-9b83-4e92-8942-8d2e72ced221)

## Checklist

- [X] I have tested these changes
- [X] I have updated the relevant documentation
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the codebase
- [X] My changes generate no new warnings or errors
- [X] The title of my pull request is clear and descriptive
