### PR TITLE
Fix: resolve admin create issue

### DIFF
--- a/frontend/src/modules/AdminCrudModule/index.jsx
+++ b/frontend/src/modules/AdminCrudModule/index.jsx
@@ -107,7 +107,7 @@ function AdminCrudModule({ config, createForm, updateForm }) {
       config={config}
       fixHeaderPanel={<FixHeaderPanel config={config} />}
       sidePanelBottomContent={
-        <CreateForm config={config} formElements={createForm} withUpload={true} />
+        <CreateForm config={config} formElements={createForm} withUpload={false} />
       }
       sidePanelTopContent={<SidePanelTopContent config={config} formElements={updateForm} />}
     >


### PR DESCRIPTION
## Description

The purpose of this pull request (PR) is to address the issue related to creating admin accounts. In earlier versions, creating a new admin account necessitated sending a multipart request. However, in this updated version, the requirement for an image associated with the admin account has been eliminated. Consequently, the request now only needs to be a straightforward create request rather than a createAndUpload request.

## Related Issues
#983 

## Steps to Test

1. Login to the admin account using those credentials: email: admin@demo.com password: admin123
2. Navigate to the settings page using sidebar
3. Navigate tp the admin subcategory
4. Try to add a new admin

## Screenshots (if applicable)

Here is the video of @ngtalexander of the issue that he faced:
https://github.com/idurar/idurar-erp-crm/assets/12747343/f6d12977-321b-4f04-a1da-1e9c4d5839fd

Here is a video after the PR:
https://github.com/idurar/idurar-erp-crm/assets/12747343/e228a571-269e-4041-b008-6e2d603dfc77



## Checklist

- [x] I have tested these changes
- [x] I have updated the relevant documentation
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the codebase
- [x] My changes generate no new warnings or errors
- [x] The title of my pull request is clear and descriptive
