### PR TITLE
Enhancement: Item Name text field in Invoice

### DIFF
--- a/frontend/src/modules/ErpPanelModule/ItemRow.jsx
+++ b/frontend/src/modules/ErpPanelModule/ItemRow.jsx
@@ -51,6 +51,12 @@ export default function ItemRow({ field, remove, current = null }) {
     setTotal(currentTotal);
   }, [price, quantity]);
 
+  const validateItemName = (_, value) => {
+    if (value && /^[a-zA-Z]{3,}[\w\s\S]*$/.test(value)) {
+      return Promise.resolve();
+    }
+    return Promise.reject(new Error('Item Name must contain at least 3 alphabetical characters.'));
+  };
   return (
     <Row gutter={[12, 12]} style={{ position: 'relative' }}>
       <Col className="gutter-row" span={5}>
@@ -62,8 +68,7 @@ export default function ItemRow({ field, remove, current = null }) {
               message: 'Missing itemName name',
             },
             {
-              pattern: /^(?!\s*$)[\s\S]+$/, // Regular expression to allow spaces, alphanumeric, and special characters, but not just spaces
-              message: 'Item Name must contain alphanumeric or special characters',
+              validator: validateItemName,
             },
           ]}
         >


### PR DESCRIPTION
## Description

When testing the form of add new invoice, i was able to enter only a "." as an item name, which is not really meaningful. I added a validation function so that the item name should at least contain 3 alphabetical characters aside from special characters/spaces.


## Screenshots 
_This is before my validation function where the dot is the item name:_
![Screenshot (455)](https://github.com/idurar/idurar-erp-crm/assets/133030569/da153db8-ce69-4781-b266-abefd4125712)
_This is after my validation function:_
![Screenshot (461)](https://github.com/idurar/idurar-erp-crm/assets/133030569/3c291486-02f5-492c-9b27-2f421c716145)

## Checklist

- [X] I have tested these changes
- [X] I have updated the relevant documentation
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the codebase
- [X] My changes generate no new warnings or errors
- [X] The title of my pull request is clear and descriptive
