### PR TITLE
Enhanced profile setting icon for avatar drop down

### DIFF
--- a/frontend/src/apps/Header/HeaderContainer.jsx
+++ b/frontend/src/apps/Header/HeaderContainer.jsx
@@ -4,7 +4,7 @@ import { Avatar, Dropdown, Layout } from 'antd';
 
 // import Notifications from '@/components/Notification';
 
-import { SettingOutlined, LogoutOutlined, AppstoreOutlined } from '@ant-design/icons';
+import { SettingOutlined, LogoutOutlined, AppstoreOutlined, ToolOutlined, UserOutlined } from '@ant-design/icons';
 
 import { selectCurrentAdmin } from '@/redux/auth/selectors';
 
@@ -64,7 +64,7 @@ export default function HeaderContent() {
       type: 'divider',
     },
     {
-      icon: <SettingOutlined />,
+      icon: <UserOutlined />,
       key: 'settingProfile',
       label: (
         <Link to={'/profile'}>
@@ -73,7 +73,7 @@ export default function HeaderContent() {
       ),
     },
     {
-      icon: <SettingOutlined />,
+      icon: <ToolOutlined />,
       key: 'settingApp',
       label: <Link to={'/settings'}>{translate('app_settings')}</Link>,
     },


### PR DESCRIPTION
## Description

I noticed that both the "Profile Settings" and "App Settings" actions in the Avatar dropdown have the same icon, so i changed both icons for more suitable ones using Ant Design.

## Screenshots (if applicable)
_This is the Before_
![Screenshot (462)](https://github.com/idurar/idurar-erp-crm/assets/133030569/8d34b22b-fda1-4fbd-af7e-dad8a49b9f70)
_This is the After_
![Screenshot (463)](https://github.com/idurar/idurar-erp-crm/assets/133030569/6927cd63-a2f5-4bb3-8e9a-9c30d0d52906)

## Checklist

- [X] I have tested these changes
- [X] I have updated the relevant documentation
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the codebase
- [X] My changes generate no new warnings or errors
- [X] The title of my pull request is clear and descriptive
