### PR TITLE
Enhanced icon for invoice form buttons

### DIFF
--- a/frontend/src/modules/ErpPanelModule/CreateItem.jsx
+++ b/frontend/src/modules/ErpPanelModule/CreateItem.jsx
@@ -16,7 +16,7 @@ import calculate from '@/utils/calculate';
 import { generate as uniqueId } from 'shortid';
 
 import Loading from '@/components/Loading';
-import { CloseCircleOutlined, PlusOutlined } from '@ant-design/icons';
+import { CloseCircleOutlined, PlusOutlined, CloseOutlined } from '@ant-design/icons';
 
 import { useNavigate } from 'react-router-dom';
 
@@ -114,7 +114,7 @@ export default function CreateItem({ config, CreateForm }) {
           <Button
             key={`${uniqueId()}`}
             onClick={() => navigate(`/${entity.toLowerCase()}`)}
-            icon={<CloseCircleOutlined />}
+            icon={<CloseOutlined />}
           >
             {translate('Cancel')}
           </Button>,


### PR DESCRIPTION
## Description

I noticed that the button save is using a "PlusOutlined" from Ant Design whereas the cancel button is using a "CloseCircleOutlined" .For a more unified design  i changed the icon of the cancel button to "CloseOutlined"

## Screenshots (if applicable)

_The before:_
![Screenshot (472)](https://github.com/idurar/idurar-erp-crm/assets/133030569/bdabd33f-1cb6-4f70-a27e-0dbe63149776)
_The after:_
![Screenshot (475)](https://github.com/idurar/idurar-erp-crm/assets/133030569/c1eacee8-a603-4bed-90b2-aef680d0f8d0)


## Checklist

- [X] I have tested these changes
- [X] I have updated the relevant documentation
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the codebase
- [X] My changes generate no new warnings or errors
- [X] The title of my pull request is clear and descriptive
