### PR TITLE
Fixed Issue: fixed typo in error message of input text field

### DIFF
--- a/frontend/src/modules/ErpPanelModule/ItemRow.jsx
+++ b/frontend/src/modules/ErpPanelModule/ItemRow.jsx
@@ -59,7 +59,7 @@ export default function ItemRow({ field, remove, current = null }) {
           rules={[
             {
               required: true,
-              message: 'Missing itemName name',
+              message: 'Missing Item Name',
             },
             {
               pattern: /^(?!\s*$)[\s\S]+$/, // Regular expression to allow spaces, alphanumeric, and special characters, but not just spaces


### PR DESCRIPTION
## Description
When creating a new invoice, and trying to sublit the form with empty item Name text field, the validation error message is displayed as  "Missing itemName name", while it should be displaying 'Missing Item Name' for a better user clarity. I changed the error message ot this text field to a more suitable one.

## Related Issues

#1010 

## Screenshots (if applicable)

Before:
![Screenshot (585)](https://github.com/idurar/idurar-erp-crm/assets/133030569/427eed85-3d4d-4470-b6c6-303d551b7574)

After:
![Screenshot (586)](https://github.com/idurar/idurar-erp-crm/assets/133030569/5e0a2662-314b-46d4-92a9-ea98ecde7642)

## Checklist

- [X] I have tested these changes
- [X] I have updated the relevant documentation
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the codebase
- [X] My changes generate no new warnings or errors
- [X] The title of my pull request is clear and descriptive
