### PR TITLE
Fixed Issue : Input of only integer numbers

### DIFF
--- a/frontend/src/modules/ErpPanelModule/ItemRow.jsx
+++ b/frontend/src/modules/ErpPanelModule/ItemRow.jsx
@@ -59,7 +59,7 @@ export default function ItemRow({ field, remove, current = null }) {
           rules={[
             {
               required: true,
-              message: 'Missing itemName name',
+              message: 'Missing Item Name',
             },
             {
               pattern: /^(?!\s*$)[\s\S]+$/, // Regular expression to allow spaces, alphanumeric, and special characters, but not just spaces

--- a/frontend/src/modules/ErpPanelModule/ItemRow.jsx
+++ b/frontend/src/modules/ErpPanelModule/ItemRow.jsx
@@ -9,6 +9,7 @@ export default function ItemRow({ field, remove, current = null }) {
   const [totalState, setTotal] = useState(undefined);
   const [price, setPrice] = useState(0);
   const [quantity, setQuantity] = useState(0);
+  const [quantityError, setQuantityError] = useState('');
 
   const money = useMoney();
   const updateQt = (value) => {
@@ -76,9 +77,19 @@ export default function ItemRow({ field, remove, current = null }) {
         </Form.Item>
       </Col>
       <Col className="gutter-row" span={3}>
-        <Form.Item name={[field.name, 'quantity']} rules={[{ required: true }]}>
-          <InputNumber style={{ width: '100%' }} min={0} onChange={updateQt} />
-        </Form.Item>
+      <Form.Item name={[field.name, 'quantity']} rules={[
+  { 
+    required: true,
+    message: 'Please enter a quantity',
+  },
+  {
+    pattern: /^\d+$/, // Regular expression to match only integer numbers
+    message: 'Quantity must be an integer',
+  },
+]}>
+  <InputNumber style={{ width: '100%' }} min={0} onChange={updateQt} />
+</Form.Item>
+{quantityError && <p style={{ color: 'red' }}>{quantityError}</p>}
       </Col>
       <Col className="gutter-row" span={4}>
         <Form.Item name={[field.name, 'price']} rules={[{ required: true }]}>


### PR DESCRIPTION
## Description
When creating a new invoice, in the quantity text field i'm unable to input decimal numbers when using the arrows, while i'm able to do so when i just write it in the text field.The quantity shouldn't be a decimal number but a whole number. I added an error message to be displayed whenever a user writes a decimal number.

## Related Issues

#1010 

## Screenshots (if applicable)
Before:
![Screenshot (587)](https://github.com/idurar/idurar-erp-crm/assets/133030569/b6252ae1-e926-4f37-ac72-4e87e10248a1)
After:
![Screenshot (588)](https://github.com/idurar/idurar-erp-crm/assets/133030569/e9763eee-883a-4b8d-9467-7e88c84ea766)

## Checklist

- [X] I have tested these changes
- [X] I have updated the relevant documentation
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the codebase
- [X] My changes generate no new warnings or errors
- [X] The title of my pull request is clear and descriptive
