### PR TITLE
Fix: Redundant Save Button

### DIFF
--- a/frontend/src/components/DataTable/DataTable.jsx
+++ b/frontend/src/components/DataTable/DataTable.jsx
@@ -7,6 +7,7 @@ import {
   EllipsisOutlined,
   RedoOutlined,
   ArrowRightOutlined,
+  SearchOutlined,
   ArrowLeftOutlined,
 } from '@ant-design/icons';
 import { Dropdown, Table, Button, Input } from 'antd';
@@ -191,6 +192,7 @@ export default function DataTable({ config, extra = [] }) {
             onChange={filterTable}
             placeholder={translate('search')}
             allowClear
+            suffix={<SearchOutlined />}
           />,
           <Button onClick={handelDataTableLoad} key={`${uniqueId()}`} icon={<RedoOutlined />}>
             {translate('Refresh')}

--- a/frontend/src/modules/InvoiceModule/Forms/InvoiceForm.jsx
+++ b/frontend/src/modules/InvoiceModule/Forms/InvoiceForm.jsx
@@ -217,13 +217,7 @@ function LoadInvoiceForm({ subTotal = 0, current = null }) {
       <Divider dashed />
       <div style={{ position: 'relative', width: ' 100%', float: 'right' }}>
         <Row gutter={[12, -5]}>
-          <Col className="gutter-row" span={5}>
-            <Form.Item>
-              <Button type="primary" htmlType="submit" icon={<PlusOutlined />} block>
-                {translate('Save')}
-              </Button>
-            </Form.Item>
-          </Col>
+         
           <Col className="gutter-row" span={4} offset={10}>
             <p
               style={{


### PR DESCRIPTION
## Description
In the create invoice form , there exists two save buttons having the same functionality .I deleted one of the redundant save buttons.


## Screenshots (if applicable)
Before:
![Screenshot (616)](https://github.com/idurar/idurar-erp-crm/assets/133030569/ede0f51f-21e3-4047-84b0-0f0f7252b88e)
After:
![Screenshot (617)](https://github.com/idurar/idurar-erp-crm/assets/133030569/7d59c55f-2dc9-4a13-bbf6-2587315dd874)

## Checklist

- [X] I have tested these changes
- [X] I have updated the relevant documentation
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the codebase
- [X] My changes generate no new warnings or errors
- [X] The title of my pull request is clear and descriptive
