### PR TITLE
fix: resolve client delete issue

### DIFF
--- a/backend/src/controllers/appControllers/clientController/remove.js
+++ b/backend/src/controllers/appControllers/clientController/remove.js
@@ -21,14 +21,14 @@ const remove = async (Model, req, res) => {
   }).exec();
 
   const [quotes, invoice] = await Promise.allSettled([resultQuotes, resultInvoice]);
-  if (quotes) {
+  if (quotes?.value) {
     return res.status(400).json({
       success: false,
       result: null,
       message: 'Cannot delete client if client have any quote  or invoice',
     });
   }
-  if (invoice) {
+  if (invoice?.value) {
     return res.status(400).json({
       success: false,
       result: null,


### PR DESCRIPTION
## Description

Unable to delete client despite absence of invoices or quotes #1025

## Related Issues

Unable to delete client despite absence of invoices or quotes #1025

## Steps to Test

- Create a new user
- Create a client attached to that user, make sure that user is not associated with any invoice.
- Try deleting user. It must be get delete now.
- Try adding client with user associated with some invoice, try deleting client, it mustn't get delete.

## Screenshots (if applicable)

N/A

## Checklist

- [x] I have tested these changes
- [x] I have updated the relevant documentation
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the codebase
- [x] My changes generate no new warnings or errors
- [x] The title of my pull request is clear and descriptive
