### PR TITLE
fix 'req is undefined' error in payment controller

### DIFF
--- a/backend/src/controllers/appControllers/paymentController/create.js
+++ b/backend/src/controllers/appControllers/paymentController/create.js
@@ -37,7 +37,7 @@ const create = async (req, res) => {
     });
   }
   req.body['createdBy'] = req.admin._id;
-  req.req.req.body['currency'] = currentInvoice.currency;
+  req.body['currency'] = currentInvoice.currency;
 
   const result = await Model.create(req.body);
 


### PR DESCRIPTION
## Description

Payment controller had multiple references to "req" object inside like ```req.req.req.body```  which caused adding payment method to fail and return internal server error. Probably a typo.

## Steps to Test

try recording payment to invoice

