### PR TITLE
Feature: Add catch-all route for SPA

### DIFF
--- a/backend/src/app.js
+++ b/backend/src/app.js
@@ -15,9 +15,11 @@ const errorHandlers = require('./handlers/errorHandlers');
 const erpApiRouter = require('./routes/appRoutes/appApi');
 
 const fileUpload = require('express-fileupload');
+const path  = require('path')
+
+
 // create our Express app
 const app = express();
-
 app.use(
   cors({
     origin: true,
@@ -41,7 +43,20 @@ app.use('/api', adminAuth.isValidAuthToken, coreApiRouter);
 app.use('/api', adminAuth.isValidAuthToken, erpApiRouter);
 app.use('/download', coreDownloadRouter);
 app.use('/public', corePublicRouter);
+const buildPath = path.join(__dirname, "../../frontend/dist"); // defining the build path
 
+// Serve static files from the frontend build directory
+app.use(express.static(buildPath));
+
+// Catch-all route to serve the frontend SPA
+app.get("/*", function(req, res) {
+  res.sendFile(path.join(buildPath, "index.html"), function (err) {
+    if (err) {
+      console.log(err);
+      res.status(500).send(err);
+    }
+  });
+});
 // If that above routes didnt work, we 404 them and forward to error handler
 app.use(errorHandlers.notFound);
 


### PR DESCRIPTION
## Description
Adding a catch-all route for serving a Single Page Application (SPA) from the backend allows you to serve the entire application from a single port, typically the backend port (port 8888 in this case), instead of running separate servers for the backend and frontend (on ports 8888 and 3000). This simplifies deployment and potentially improves performance by reducing network overhead. After adding this route, users can access the application through the backend port, and the frontend will be served seamlessly. However, it's essential to build the frontend application before deploying (using the `npm run build` command) to ensure that the frontend assets are available to be served by the backend.

## Related Issues

No related issues this is a feature

## Steps to Test

1. navigate to the frontend folder `cd frontend`
2. build the app `npm run build`
3. navigate to the backend folder `cd ../backend`
4. start the backend `npm run dev`
5. open this link in the browser `http://localhost:8888`
6. if it opens and you can login then everything works fine

## Screenshots (if applicable)

Before:
![Screenshot 2024-04-28 133725](https://github.com/idurar/idurar-erp-crm/assets/97735538/006efc26-08b4-47e8-b7d9-307d6805196a)

After:
![Screenshot 2024-04-28 133705](https://github.com/idurar/idurar-erp-crm/assets/97735538/3936b160-fcb0-4782-888e-845f7fb9aba7)


## Checklist

- [x] I have tested these changes
- [x] I have updated the relevant documentation
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the codebase
- [x] My changes generate no new warnings or errors
- [x] The title of my pull request is clear and descriptive
