### PR TITLE
fix: notes visible in leads sidepane

### DIFF
--- a/backend/src/controllers/appControllers/leadController/migrate.js
+++ b/backend/src/controllers/appControllers/leadController/migrate.js
@@ -13,5 +13,6 @@ exports.migrate = (result) => {
   newData.address = lead.address;
   newData.people = result.people;
   newData.company = result.company;
+  newData.notes = result.notes;
   return newData;
 };


### PR DESCRIPTION
## Description

Notes was not showing on the UI in leads tab .
## Related Issues

Issue #1085

## Steps to Test

Goto Leads tab fron side nav ,create a lead , click on 3 dots and select show there in the notes we were not able to see notes. 



## Checklist

- [ Y] I have tested these changes
- [Y ] I have updated the relevant documentation
- [Y ] I have commented my code, particularly in hard-to-understand areas
- [ Y] I have made corresponding changes to the codebase
- [ Y] My changes generate no new warnings or errors
- [ Y] The title of my pull request is clear and descriptive
