### PR TITLE
Fix:Cannot-Delete-Client

### DIFF
--- a/backend/src/controllers/appControllers/clientController/remove.js
+++ b/backend/src/controllers/appControllers/clientController/remove.js
@@ -20,7 +20,7 @@ const remove = async (Model, req, res) => {
     removed: false,
   }).exec();
 
-  const [quotes, invoice] = await Promise.allSettled([resultQuotes, resultInvoice]);
+  const [quotes, invoice] = await Promise.all([resultQuotes, resultInvoice]);
   if (quotes) {
     return res.status(400).json({
       success: false,


### PR DESCRIPTION
## Description

This pull request addresses the issue related to the deletion of clients. Previously, clients were not being deleted if they didn't have any associated invoices, leading to unexpected behavior. With this update, the deletion process has been revised to align with the expected behavior.
promise.allSettled return an object of enteries 'status' and 'value' but we just need 'value' here so promise.all is accurate here.

## Related Issues

#1013 #1086 


## Steps to Test

Provide steps on how to test the changes introduced in this pull request.

## Screenshots (if applicable)

Before:
![ss-before](https://github.com/idurar/idurar-erp-crm/assets/59303660/74d5eaa3-8f30-49e8-888a-ca58c0729805)


After:
![ss-after](https://github.com/idurar/idurar-erp-crm/assets/59303660/3cd8c2f0-5dd3-4ddf-b2f1-720f61bba240)

## Checklist

- [x] I have tested these changes
- [x] I have updated the relevant documentation
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the codebase
- [x] My changes generate no new warnings or errors
- [x] The title of my pull request is clear and descriptive

