### PR TITLE
Fix issue #1101: "Please enter enabled" error was resolved

### DIFF
--- a/backend/.env
+++ b/backend/.env
@@ -1,7 +1,7 @@
-#DATABASE = "mongodb://localhost:27017"
+DATABASE = "mongodb://localhost:27017/idurar"
 #RESEND_API = "your resend_api"
 #OPENAI_API_KEY = "your open_ai api key"
-JWT_SECRET= "your_private_jwt_secret_key"
+JWT_SECRET= "idurar123"
 NODE_ENV = "production"
 OPENSSL_CONF='/dev/null'
 PUBLIC_SERVER_FILE="http://localhost:8888/"

--- a/frontend/src/components/CreateForm/index.jsx
+++ b/frontend/src/components/CreateForm/index.jsx
@@ -46,7 +46,7 @@ export default function CreateForm({ config, formElements, withUpload = false })
 
   return (
     <Loading isLoading={isLoading}>
-      <Form form={form} layout="vertical" onFinish={onSubmit}>
+      <Form form={form} layout="vertical" onFinish={onSubmit} initialValues={{ enabled: true }}>
         {formElements}
         <Form.Item>
           <Button type="primary" htmlType="submit">


### PR DESCRIPTION
## Description

When the admin wants to add new product category, the enabled switch was initially undefined. Due to which the enabled switch had to be pressed twice to make it true otherwise it shows error while submitting the form. I resolved it by assigning initial values of enabled so that admin does not get validation error while submitting the form. 

## Related Issues

The form displayed an error message saying "Please enter enabled" when initially rendered. This was due to the 'enabled' field not having a initial value set, causing validation to fail on initial page load.

## Steps to Test

1. Go to productCategory
2. Click on Add new and add the name ,description ,color
3. Submit and the error "Please enter Enabled" is gone.(Previously you have to click the switch twice to make the enabled value to be true)

## Testing

- Verified that the form loads without showing the "Please enter enabled" error message.
- Tested various form submissions to ensure validation works as expected with the initial value set to true.
