### PR TITLE
Fixed typo ('People' from 'Peoples')

### DIFF
--- a/backend/src/locale/translation/en_us.js
+++ b/backend/src/locale/translation/en_us.js
@@ -432,7 +432,7 @@ module.exports = {
   do_you_need_help_on_customize_of_this_app: 'Do You Need Help On Customize Of This App',
   contact_us: 'Contact Us',
   customers: 'Customers',
-  peoples: 'Peoples',
+  people: 'People',
   companies: 'Companies',
   leads: 'Leads',
   offer_leads: 'Offer Leads',

--- a/backend/src/models/appModels/Company.js
+++ b/backend/src/models/appModels/Company.js
@@ -31,7 +31,7 @@ const schema = new mongoose.Schema({
     type: Boolean,
     default: false,
   },
-  peoples: [{ type: mongoose.Schema.ObjectId, ref: 'People', autopopulate: true }],
+  people: [{ type: mongoose.Schema.ObjectId, ref: 'People', autopopulate: true }],
   mainContact: { type: mongoose.Schema.ObjectId, ref: 'People', autopopulate: true },
   icon: {
     type: String,

--- a/frontend/src/apps/Navigation/NavigationContainer.jsx
+++ b/frontend/src/apps/Navigation/NavigationContainer.jsx
@@ -64,7 +64,7 @@ function Sidebar({ collapsible, isMobile = false }) {
     {
       key: 'people',
       icon: <UserOutlined />,
-      label: <Link to={'/people'}>{translate('peoples')}</Link>,
+      label: <Link to={'/people'}>{translate('people')}</Link>,
     },
     {
       key: 'company',

--- a/frontend/src/locale/translation/en_us.js
+++ b/frontend/src/locale/translation/en_us.js
@@ -432,7 +432,7 @@ const lang = {
   do_you_need_help_on_customize_of_this_app: 'Do You Need Help On Customize Of This App',
   contact_us: 'Contact Us',
   customers: 'Customers',
-  peoples: 'Peoples',
+  people: 'People',
   companies: 'Companies',
   leads: 'Leads',
   offer_leads: 'Offer Leads',


### PR DESCRIPTION
## Description
Fixed a typo in the dashboard. Changed peoples into people.

## Related Issues
Bug: Peoples Tab Typo on Home View #1135

