### PR TITLE
Remove language header from login page

### DIFF
--- a/frontend/src/components/SelectLanguage/index.jsx
+++ b/frontend/src/components/SelectLanguage/index.jsx
@@ -42,7 +42,8 @@ const SelectLanguage = () => {
         style={{
           width: isMobile ? '100px' : '130px',
           float: 'right',
-          marginTop: '5px',
+          marginTop: '10px',
+          marginRight: '10px',
           cursor: 'pointer',
           direction: 'ltr',
         }}

--- a/frontend/src/layout/AuthLayout/index.jsx
+++ b/frontend/src/layout/AuthLayout/index.jsx
@@ -3,20 +3,12 @@ import { Layout, Row, Col } from 'antd';
 import { selectLangDirection } from '@/redux/translate/selectors';
 import { useSelector } from 'react-redux';
 import { Content } from 'antd/lib/layout/layout';
-import SelectLanguage from '@/components/SelectLanguage';
+
 export default function AuthLayout({ sideContent, children }) {
   const langDirection = useSelector(selectLangDirection)
 
   return (
     <Layout style={{ textAlign: langDirection === "rtl" ? "right" : "left",direction:langDirection}}>
-      <Content
-          style={{
-            padding: '10px 20px'
-          }}
-
-        >
-          <SelectLanguage />
-        </Content>
         <Row>
           <Col
             xs={{ span: 0, order: 2 }}

--- a/frontend/src/modules/AuthModule/index.jsx
+++ b/frontend/src/modules/AuthModule/index.jsx
@@ -5,7 +5,6 @@ import { Layout, Col, Divider, Typography } from 'antd';
 import AuthLayout from '@/layout/AuthLayout';
 import SideContent from './SideContent';
 import SelectLanguage from '@/components/SelectLanguage';
-
 import logo from '@/style/images/idurar-crm-erp.svg';
 import { selectLangDirection } from '@/redux/translate/selectors';
 import { useSelector } from 'react-redux';
@@ -17,7 +16,7 @@ const AuthModule = ({ authContent, AUTH_TITLE, isForRegistre = false }) => {
   const translate = useLanguage();
   return (
       <AuthLayout sideContent={<SideContent />}>
-      
+        <SelectLanguage />
         <Content
           style={{
             padding: isForRegistre ? '40px 30px 30px' : '100px 30px 30px',


### PR DESCRIPTION
## Description

While accessing the initial login page, the language choice button is rendered in a header on top of the sections. 

## Related Issues

Didn't find any related issues. 

## Steps to Test

1. Run the application locally
2. Navigate to initial login page 

## Screenshots (if applicable)

Before: 

<img width="1920" alt="Screenshot 2024-07-05 at 6 37 25" src="https://github.com/idurar/idurar-erp-crm/assets/45930931/c0b0a039-40a2-47ce-816d-941b30d1ca44">

After: 

<img width="1920" alt="Screenshot 2024-07-05 at 6 43 05" src="https://github.com/idurar/idurar-erp-crm/assets/45930931/57f664e9-c3d2-4e7c-9f2f-32ec10f97123">

## Checklist

- [X] I have tested these changes
- [ ] I have updated the relevant documentation
- [ ] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the codebase
- [X] My changes generate no new warnings or errors
- [X] The title of my pull request is clear and descriptive
