### PR TITLE
Fix typo: 'Peoples' to 'People' in the main dashboard

### DIFF
--- a/frontend/src/apps/Navigation/NavigationContainer.jsx
+++ b/frontend/src/apps/Navigation/NavigationContainer.jsx
@@ -64,7 +64,7 @@ function Sidebar({ collapsible, isMobile = false }) {
     {
       key: 'people',
       icon: <UserOutlined />,
-      label: <Link to={'/people'}>{translate('peoples')}</Link>,
+      label: <Link to={'/people'}>{translate('people')}</Link>,
     },
     {
       key: 'company',


### PR DESCRIPTION
Description
Fixed an issue by navigating to the navigation container and updating the frontend to replace "peoples" with "people."

Related Issues
N/A

Steps to Test
Navigate to the navigation container in the codebase.
Verify that "peoples" has been replaced with "people" in the frontend.
Test the functionality to ensure there are no issues.
Screenshots
[View the changes here](https://github.com/user-attachments/assets/bd0851d3-fb22-48dc-8eb0-3de2f121b1f1)

Checklist
 I have tested these changes
 I have updated the relevant documentation
 I have commented my code, particularly in hard-to-understand areas
 I have made corresponding changes to the codebase
 My changes generate no new warnings or errors
 The title of my pull request is clear and descriptive