### PR TITLE
fix: correct the typo in dashboard

### DIFF
--- a/frontend/src/modules/DashboardModule/components/CustomerPreviewCard.jsx
+++ b/frontend/src/modules/DashboardModule/components/CustomerPreviewCard.jsx
@@ -32,10 +32,10 @@ export default function CustomerPreviewCard({
               }}
             >
               <Progress type="dashboard" percent={newCustomer} size={148} />
-              <p>{translate("New Customer this Month")}</p>
+              <p>{translate("New Customers this Month")}</p>
               <Divider />
               <Statistic
-                title={translate("Active Customer")}
+                title={translate("Active Customers")}
                 value={activeCustomer}
                 precision={2}
                 valueStyle={


### PR DESCRIPTION
## Description
fixes the typo in the dashboard of homepage from 'Customer' to 'Customers'

Fixes #1158 

## Steps to Test
- Login in
- Go to home page
- Check the bottom left corner and see that the customer spelling in Customer dashBoard is corrected.

## Screenshots (if applicable)
