### PR TITLE
Update the functionality of onChange listener in general setting

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "idurar-erp-crm",
-  "version": "4.0.0-beta.3",
+  "version": "4.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "idurar-erp-crm",
-      "version": "4.0.0-beta.3",
+      "version": "4.0.0",
       "license": "Fair-code License",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.509.0",

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "idurar-erp-crm",
-  "version": "4.0.0-beta.3",
+  "version": "4.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "idurar-erp-crm",
-      "version": "4.0.0-beta.3",
+      "version": "4.0.0",
       "dependencies": {
         "@ant-design/icons": "^5.3.0",
         "@ant-design/pro-layout": "^7.17.19",

--- a/frontend/src/pages/Settings/Settings.jsx
+++ b/frontend/src/pages/Settings/Settings.jsx
@@ -23,8 +23,12 @@ export default function Settings() {
   const content = [
     {
       key: 'general_settings',
-      label: translate('General Settings'),
-      icon: <SettingOutlined />,
+      label: (
+        <span onClick={(e) => e.stopPropagation()}>
+          <SettingOutlined />
+          {translate('General Settings')}
+        </span>
+      ),
       children: <GeneralSettings />,
     },
     {


### PR DESCRIPTION
## Description

Update the functionality of onChange Click listener in General setting.

## Related Issues

Fixes #807 

## Screenshots (if applicable)

![Screenshot 2024-09-11 170001](https://github.com/user-attachments/assets/a827c325-38dd-486a-abc7-8ab6d29d8b37)

##Detail Description: -

This pull request addresses an issue where the navigation in the settings page only works when clicking on the text, not the entire tab area. The changes ensure that the navigation is triggered only when the text is clicked, preventing clicks on the surrounding div from affecting the navigation.

##Changes Made:

1.Wrapped the text in each tab label with a span element.
2.Added onClick event handlers to the span elements to stop event propagation.


##Files Modified:
Settings.js

##Steps to Reproduce the Issue:
1.Navigate to the settings page.
2.Try clicking on the tab area outside the text.
3.Observe that the navigation does not work unless the text is clicked.


##Steps to Verify the Fix:

1.Navigate to the settings page.
2.Click directly on the text in the tab.
3.Verify that the navigation works as expected.

