### PR TITLE
fix: resolved whitespace issue in AdminForm

### DIFF
--- a/frontend/src/modules/ProfileModule/components/ProfileAdminForm.jsx
+++ b/frontend/src/modules/ProfileModule/components/ProfileAdminForm.jsx
@@ -16,8 +16,17 @@ const beforeUpload = (file) => {
   return false;
 };
 
-export default function AdminForm({ isUpdateForm = false }) {
+export default function AdminForm({ isUpdateForm = false, form }) {
   const translate = useLanguage();
+  const handleInputChange = (e, fieldName) => {
+    const value = e.target.value.trim();
+    form.setFieldsValue({
+      [fieldName]: value === '' ? '' : e.target.value, // Set empty string if only whitespace
+    });
+
+    form.validateFields([fieldName]);
+  };
+
   return (
     <>
       <Form.Item
@@ -29,7 +38,7 @@ export default function AdminForm({ isUpdateForm = false }) {
           },
         ]}
       >
-        <Input autoComplete="off" />
+        <Input autoComplete="off" onChange={(e) => handleInputChange(e, 'name')} />
       </Form.Item>
       <Form.Item
         label={translate('last Name')}
@@ -40,7 +49,7 @@ export default function AdminForm({ isUpdateForm = false }) {
           },
         ]}
       >
-        <Input autoComplete="off" />
+        <Input autoComplete="off" onChange={(e) => handleInputChange(e, 'surname')} />
       </Form.Item>
       <Form.Item
         label={translate('email')}

--- a/frontend/src/modules/ProfileModule/components/UpdateAdmin.jsx
+++ b/frontend/src/modules/ProfileModule/components/UpdateAdmin.jsx
@@ -81,7 +81,7 @@ const UpdateAdmin = ({ config }) => {
             labelCol={{ span: 6 }}
             wrapperCol={{ span: 10 }}
           >
-            <ProfileAdminForm isUpdateForm={true} />
+            <ProfileAdminForm isUpdateForm={true} form={form} />
           </Form>
         </Col>
       </Row>


### PR DESCRIPTION
## Description

The Admin Form was accepting white spaces but the fields were required. So I added a form validation to avoid the user from entering whitespaces. The detailed issue can be seen here #1162 .

## Related Issues

Fixes #1162 

## Steps to Test

1. Navigate to Home page.
2. Go to Profile settings from the profile icon on top right corner.
3. Click on Edit button
4. If blank spaces are given in input for "First Name" and "Last Name" it will not accept it and show validation error.

## Screenshots (if applicable)

Before:
![image](https://github.com/user-attachments/assets/c472c380-176f-4e48-8a46-b751f998fd57)

After:
![image](https://github.com/user-attachments/assets/9fc4768b-6170-482e-b37e-a11aee65d3f1)

## Modified files

1. ProfileAdminForm.jsx
2. UpdateAdmin.jsx
