### PR TITLE
fix: added space between delete message and the deleting item

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "idurar-erp-crm",
-  "version": "4.0.0",
+  "version": "4.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "idurar-erp-crm",
-      "version": "4.0.0",
+      "version": "4.1.0",
       "license": "Fair-code License",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.509.0",

--- a/frontend/src/components/DeleteModal/index.jsx
+++ b/frontend/src/components/DeleteModal/index.jsx
@@ -62,8 +62,7 @@ export default function DeleteModal({ config }) {
       confirmLoading={isLoading}
     >
       <p>
-        {deleteMessage}
-        {displayItem}
+        {deleteMessage} {displayItem}
       </p>
     </Modal>
   );


### PR DESCRIPTION
## Description

Added a space between the message **Are You Sure You Want To Delete** and the name of customer

## Related Issues

fixes #1178

## Steps to Test

Go to customers and add new client and then delete it, in the delete message you will see a space between delete message and the customer name

## Screenshots (if applicable)
![Screenshot from 2024-10-17 17-07-50](https://github.com/user-attachments/assets/d7f5b9a7-79ae-411a-928b-6038045ad905)



## Checklist

- [ ] I have tested these changes
- [ ] I have made corresponding changes to the codebase
- [ ] My changes generate no new warnings or errors
- [ ] The title of my pull request is clear and descriptive
