### PR TITLE
Fix #1222: Handle unregistered email in forgot password route with 404 

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "idurar-erp-crm",
-  "version": "4.0.0",
+  "version": "4.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "idurar-erp-crm",
-      "version": "4.0.0",
+      "version": "4.1.0",
       "license": "Fair-code License",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.509.0",

--- a/backend/src/controllers/middlewaresControllers/createAuthMiddleware/forgetPassword.js
+++ b/backend/src/controllers/middlewaresControllers/createAuthMiddleware/forgetPassword.js
@@ -1,79 +1,91 @@
 const Joi = require('joi');
-
 const mongoose = require('mongoose');
-
 const checkAndCorrectURL = require('./checkAndCorrectURL');
 const sendMail = require('./sendMail');
 const shortid = require('shortid');
-const { loadSettings } = require('@/middlewares/settings');
-
 const { useAppSettings } = require('@/settings');
 
 const forgetPassword = async (req, res, { userModel }) => {
-  const UserPassword = mongoose.model(userModel + 'Password');
-  const User = mongoose.model(userModel);
-  const { email } = req.body;
+  try {
+    const UserPassword = mongoose.model(userModel + 'Password');
+    const User = mongoose.model(userModel);
+    const { email } = req.body;
+    // validate email
 
-  // validate
-  const objectSchema = Joi.object({
-    email: Joi.string()
-      .email({ tlds: { allow: true } })
-      .required(),
-  });
+    const { error } = Joi.object({
+      email: Joi.string()
+        .email({ tlds: { allow: true } })
+        .required(),
+    }).validate({ email });
 
-  const { error, value } = objectSchema.validate({ email });
-  if (error) {
-    return res.status(409).json({
+    if (error) {
+      return res.status(400).json({
+        success: false,
+        result: null,
+        error: error,
+        message: 'Invalid email.',
+        errorMessage: error.message,
+      });
+    }
+    const user = await User.findOne({ email: email, removed: false });
+    // console.log(user);
+    if (!user) {
+      return res.status(404).json({
+        success: false,
+        result: null,
+        message: 'No account with this email has been registered.',
+      });
+    }
+
+    const resetToken = shortid.generate();
+    const userPassword = await UserPassword.findOneAndUpdate(
+      { user: user._id },
+      { resetToken },
+      {
+        new: true,
+        upsert: true,
+      }
+    ).exec();
+    // Check if update was successful
+    if (!userPassword) {
+      return res.status(500).json({
+        success: false,
+        result: null,
+        message: 'Error updating reset token. Please try again.',
+      });
+    }
+
+    const settings = useAppSettings();
+    const idurar_app_email = settings['idurar_app_email'];
+    const idurar_base_url = settings['idurar_base_url'];
+
+    const url = checkAndCorrectURL(idurar_base_url);
+
+    const link = `${url}/resetpassword/${user._id}/${resetToken}`;
+
+    await sendMail({
+      email,
+      name: user.name,
+      link,
+      subject: 'Reset your password | idurar',
+      idurar_app_email,
+      type: 'passwordVerification',
+    });
+
+    return res.status(200).json({
+      success: true,
+      result: null,
+      message: 'Check your email inbox to reset your password',
+    });
+  } catch (err) {
+    console.error('Forget Password Error:', err);
+    return res.status(500).json({
       success: false,
       result: null,
-      error: error,
-      message: 'Invalid email.',
-      errorMessage: error.message,
+      message: 'An unexpected error occurred. Please try again later.',
+      error: err.message,
     });
   }
-
-  const user = await User.findOne({ email: email, removed: false });
-  const databasePassword = await UserPassword.findOne({ user: user._id, removed: false });
-
-  // console.log(user);
-  if (!user)
-    return res.status(404).json({
-      success: false,
-      result: null,
-      message: 'No account with this email has been registered.',
-    });
-
-  const resetToken = shortid.generate();
-  await UserPassword.findOneAndUpdate(
-    { user: user._id },
-    { resetToken },
-    {
-      new: true,
-    }
-  ).exec();
-
-  const settings = useAppSettings();
-  const idurar_app_email = settings['idurar_app_email'];
-  const idurar_base_url = settings['idurar_base_url'];
-
-  const url = checkAndCorrectURL(idurar_base_url);
-
-  const link = url + '/resetpassword/' + user._id + '/' + resetToken;
-
-  await sendMail({
-    email,
-    name: user.name,
-    link,
-    subject: 'Reset your password | idurar',
-    idurar_app_email,
-    type: 'passwordVerfication',
-  });
-
-  return res.status(200).json({
-    success: true,
-    result: null,
-    message: 'Check your email inbox , to reset your password',
-  });
 };
 
 module.exports = forgetPassword;


### PR DESCRIPTION
# Forgot Password Functionality - Error Handling Update

## Description

This update improves the error handling and response structure for the forgot password functionality:

- Email input validation: Returns `400 Bad Request` for invalid emails.
- Returns a `404 Not Found` if the provided email is not registered.
- Used `upsert: true` for reset token updates to ensure token is either created or updated correctly.
- Wrapped the entire function in a `try-catch` block to handle unexpected errors and return `500 Internal Server Error` when needed.

## Related Issues

-#1222

## Steps to Test

1. **Test with a registered email:**
   - Ensure a reset token is generated, and an email is sent to the user.

2. **Test with an unregistered email:**
   - Confirm that a `404 Not Found` response is returned with the message:
     - "No account with this email has been registered."

3. **Test with an invalid email format:**
   - Verify a `400 Bad Request` response is returned with the message:
     - "Invalid email."

## Checklist

- [ ] I have tested these changes.
- [ ] I have updated the relevant documentation.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] My changes generate no new warnings or errors.
- [ ] The title of my pull request is clear and descriptive.
