### PR TITLE
fixed typo Default Payment Mode (Cash , Wire Transfert)

### DIFF
--- a/backend/src/controllers/coreControllers/setup.js
+++ b/backend/src/controllers/coreControllers/setup.js
@@ -86,7 +86,7 @@ const setup = async (req, res) => {
   await PaymentMode.insertMany([
     {
       name: 'Default Payment',
-      description: 'Default Payment Mode (Cash , Wire Transfert)',
+      description: 'Default Payment Mode (Cash , Wire Transfer)',
       isDefault: true,
     },
   ]);


### PR DESCRIPTION
Typo in Default Payment Mode

This pull request fixes a typo in the Default Payment Mode text. Previously, "Wire Transfert" was incorrectly spelled. It has now been corrected to "Wire Transfer" for accuracy and consistency.