### PR TITLE
Add the register route for locally register user and test the applicatio

### DIFF
--- a/backend/src/controllers/middlewaresControllers/createAuthMiddleware/index.js
+++ b/backend/src/controllers/middlewaresControllers/createAuthMiddleware/index.js
@@ -3,9 +3,16 @@ const login = require('./login');
 const logout = require('./logout');
 const forgetPassword = require('./forgetPassword');
 const resetPassword = require('./resetPassword');
+const register = require('./register')
 
 const createAuthMiddleware = (userModel) => {
   let authMethods = {};
+
+  
+  authMethods.register = (req, res, next) => 
+    register(req, res, next, {
+      userModel,
+    });
 
   authMethods.isValidAuthToken = (req, res, next) =>
     isValidAuthToken(req, res, next, {

--- a/backend/src/controllers/middlewaresControllers/createAuthMiddleware/register.js
+++ b/backend/src/controllers/middlewaresControllers/createAuthMiddleware/register.js
@@ -1,0 +1,41 @@
+const mongoose = require('mongoose');
+const bcrypt = require('bcryptjs');
+const jwt = require('jsonwebtoken');
+
+const authUser = require('./authUser');
+
+const register = async (req, res, next, { userModel }) => {
+  try {
+    const UserModel = mongoose.model(userModel);
+    const { name, email, password } = req.body;
+
+    // Check if user already exists
+    const existingUser = await UserModel.findOne({ email });
+    if (existingUser) {
+      return res.status(409).json({ success: false, message: 'User already exists' });
+    }
+
+    // Hash password
+    const hashedPassword = await bcrypt.hash(password, 10);
+
+    // Create new user
+    const newUser = await UserModel.create({ name, email, password: hashedPassword });
+
+    // Generate token (optional)
+    const token = jwt.sign({ id: newUser._id }, process.env.JWT_SECRET, { expiresIn: '1d' });
+
+    res.status(201).json({
+      success: true,
+      message: 'User registered successfully',
+      data: {
+        user: { id: newUser._id, name: newUser.name, email: newUser.email },
+        token,
+      },
+    });
+  } catch (error) {
+    console.error('Register Error:', error);
+    res.status(500).json({ success: false, message: 'Registration failed', error });
+  }
+};
+
+module.exports = register;

--- a/backend/src/routes/coreRoutes/coreAuth.js
+++ b/backend/src/routes/coreRoutes/coreAuth.js
@@ -7,7 +7,10 @@ const adminAuth = require('@/controllers/coreControllers/adminAuth');
 
 router.route('/login').post(catchErrors(adminAuth.login));
 
+router.route('/register').post(catchErrors(adminAuth.register))
+
 router.route('/forgetpassword').post(catchErrors(adminAuth.forgetPassword));
+
 router.route('/resetpassword').post(catchErrors(adminAuth.resetPassword));
 
 router.route('/logout').post(adminAuth.isValidAuthToken, catchErrors(adminAuth.logout));

--- a/frontend/src/auth/auth.service.js
+++ b/frontend/src/auth/auth.service.js
@@ -5,12 +5,14 @@ import errorHandler from '@/request/errorHandler';
 import successHandler from '@/request/successHandler';
 
 export const login = async ({ loginData }) => {
+  console.log(loginData)
   try {
     const response = await axios.post(
       API_BASE_URL + `login?timestamp=${new Date().getTime()}`,
       loginData
     );
 
+    console.log(response)
     const { status, data } = response;
 
     successHandler(
@@ -28,7 +30,10 @@ export const login = async ({ loginData }) => {
 
 export const register = async ({ registerData }) => {
   try {
-    const response = await axios.post(API_BASE_URL + `register`, registerData);
+    const response = await axios.post(
+      API_BASE_URL + `register`, 
+      registerData
+    );
 
     const { status, data } = response;
 
@@ -41,6 +46,7 @@ export const register = async ({ registerData }) => {
     );
     return data;
   } catch (error) {
+    console.log(error)
     return errorHandler(error);
   }
 };

--- a/frontend/src/pages/Register.jsx
+++ b/frontend/src/pages/Register.jsx
@@ -1,0 +1,63 @@
+import { useEffect } from 'react';
+
+import { useDispatch, useSelector } from 'react-redux';
+import { useNavigate } from 'react-router-dom';
+
+import useLanguage from '@/locale/useLanguage';
+
+import { Form, Button } from 'antd';
+
+import { register } from '@/redux/auth/actions';
+import { selectAuth } from '@/redux/auth/selectors';
+import Loading from '@/components/Loading';
+import AuthModule from '@/modules/AuthModule';
+import RegisterForm from '@/forms/RegisterForm';
+
+const Register = () => {
+  const translate = useLanguage();
+  const { isLoading, isSuccess } = useSelector(selectAuth);
+  const navigate = useNavigate();
+  // const size = useSize();
+
+  const dispatch = useDispatch();
+  const onFinish = (values) => {
+    dispatch(register({ registerData: values }));
+  };
+
+  useEffect(() => {
+    if (isSuccess) navigate('/');
+  }, [isSuccess]);
+
+  const FormContainer = () => {
+    return (
+      <Loading isLoading={isLoading}>
+        <Form
+          layout="vertical"
+          name="normal_login"
+          className="login-form"
+          initialValues={{
+            remember: true,
+          }}
+          onFinish={onFinish}
+        >
+          <RegisterForm />
+          <Form.Item>
+            <Button
+              type="primary"
+              htmlType="submit"
+              className="login-form-button"
+              loading={isLoading}
+              size="large"
+            >
+              {translate('Register')}
+            </Button>
+          </Form.Item>
+        </Form>
+      </Loading>
+    );
+  };
+
+  return <AuthModule authContent={<FormContainer />} AUTH_TITLE="Register" />;
+};
+
+export default Register;

--- a/frontend/src/router/AuthRouter.jsx
+++ b/frontend/src/router/AuthRouter.jsx
@@ -7,6 +7,7 @@ import ForgetPassword from '@/pages/ForgetPassword';
 import ResetPassword from '@/pages/ResetPassword';
 
 import { useDispatch } from 'react-redux';
+import Register from '@/pages/Register';
 
 export default function AuthRouter() {
   const dispatch = useDispatch();
@@ -14,6 +15,7 @@ export default function AuthRouter() {
   return (
     <Routes>
       <Route element={<Login />} path="/" />
+      <Route element={<Register />} path="/register" />
       <Route element={<Login />} path="/login" />
       <Route element={<Navigate to="/login" replace />} path="/logout" />
       <Route element={<ForgetPassword />} path="/forgetpassword" />

--- a/frontend/src/router/routes.jsx
+++ b/frontend/src/router/routes.jsx
@@ -2,6 +2,7 @@ import { lazy } from 'react';
 
 import { Navigate } from 'react-router-dom';
 
+const Register = lazy(() => import('@/pages/Register.jsx'));
 const Logout = lazy(() => import('@/pages/Logout.jsx'));
 const NotFound = lazy(() => import('@/pages/NotFound.jsx'));
 
@@ -32,6 +33,10 @@ const About = lazy(() => import('@/pages/About'));
 let routes = {
   expense: [],
   default: [
+    {
+      path: '/register',
+      element: <Navigate to= '/register' />,
+    },
     {
       path: '/login',
       element: <Navigate to="/" />,


### PR DESCRIPTION
## Description

This pull request adds a new /register route to allow local user registration (not via third-party auth). It includes the necessary controller logic, model validation, and route integration. Additionally, basic tests have been conducted to ensure the registration flow works as expected.

## Related Issues

Closes #1248 

## Steps to Test

1) Run the development server :  ``` npm run dev ```
2) Send a POST request to: ``` http://localhost:3000/api/auth/register ```
3) Body payload example (JSON): 

    ```
    {
       "name": "Test User",
       "email": "test@example.com",
       "password": "test123"
    }

```
4) Check the response and ensure the user is saved to the database.
5) Try registering with an existing email to test validation.

## Screenshots (if applicable)

## Before

![before](https://github.com/user-attachments/assets/a4c0b218-2342-4a5e-87a4-13257f4277de)


## After

![Annotation 2025-05-13 221059](https://github.com/user-attachments/assets/612b7a6b-1afb-4be9-93c8-6a36090391c6)


## Checklist

- [x] I have tested these changes
- [x] I have updated the relevant documentation
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the codebase
- [x] My changes generate no new warnings or errors
- [x] The title of my pull request is clear and descriptive
