### PR TITLE
fix: fix typo on RootApp.jsx

### DIFF
--- a/frontend/src/RootApp.jsx
+++ b/frontend/src/RootApp.jsx
@@ -8,7 +8,7 @@ import PageLoader from '@/components/PageLoader';
 
 const IdurarOs = lazy(() => import('./apps/IdurarOs'));
 
-export default function RoutApp() {
+export default function RootApp() {
   return (
     <BrowserRouter>
       <Provider store={store}>


### PR DESCRIPTION
## Description

Fix a typo on RootApp.jsx
typo "RoutApp" to "RootApp"

## Related Issues

- [Issue #1253](https://github.com/idurar/idurar-erp-crm/issues/1253)

## Checklist

- [ ] I have tested these changes
- [ ] I have updated the relevant documentation
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the codebase
- [ ] My changes generate no new warnings or errors
- [x] The title of my pull request is clear and descriptive
