### PR TITLE
fix: correct typo 'transfert' to 'transfer'

### DIFF
--- a/backend/src/controllers/coreControllers/setup.js
+++ b/backend/src/controllers/coreControllers/setup.js
@@ -86,7 +86,7 @@ const setup = async (req, res) => {
   await PaymentMode.insertMany([
     {
       name: 'Default Payment',
-      description: 'Default Payment Mode (Cash , Wire Transfert)',
+      description: 'Default Payment Mode (Cash , Wire Transfer)',
       isDefault: true,
     },
   ]);

--- a/backend/src/setup/setup.js
+++ b/backend/src/setup/setup.js
@@ -60,7 +60,7 @@ async function setupApp() {
     await PaymentMode.insertMany([
       {
         name: 'Default Payment',
-        description: 'Default Payment Mode (Cash , Wire Transfert)',
+        description: 'Default Payment Mode (Cash , Wire Transfer)',
         isDefault: true,
       },
     ]);


### PR DESCRIPTION
## Description

Fixed a typo in the default payment mode label. Changed "Wire Transfert" to "Wire Transfer".

## Related Issues

This addresses the bug: "Default payment mode has typo".

## Steps to Test

1. Go to the relevant section where "Default Payment Mode" is displayed.
2. Ensure that the label now correctly shows "Wire Transfer" instead of "Wire Transfert".

## Checklist

-  I have tested these changes
-  My changes generate no new warnings or errors
- The title of my pull request is clear and descriptive
