### PR TITLE
fix: load .env and .env.local files with explicit relative paths in setup script

### DIFF
--- a/backend/src/setup/setup.js
+++ b/backend/src/setup/setup.js
@@ -1,5 +1,7 @@
-require('dotenv').config({ path: '.env' });
-require('dotenv').config({ path: '.env.local' });
+const path = require('path');
+require('dotenv').config({path: path.resolve(__dirname,'../../.env')});
+require('dotenv').config({path: path.resolve(__dirname,'../../.env.local')});
+
 const { globSync } = require('glob');
 const fs = require('fs');
 const { generate: uniqueId } = require('shortid');


### PR DESCRIPTION
## Description

This pull request fixes the issue where environment variables were not loaded correctly in the setup script due to relative path mismatches with the `.env` file. The dotenv configuration has been updated to explicitly load the `.env` file from the correct project root directory to ensure MongoDB connection strings and other environment variables are properly loaded.

## Related Issues

This resolves issues related to MongoDB connection failures caused by missing or undefined environment variables during initial setup.

## Steps to Test

1. Ensure the `.env` file is located at the root of the backend directory.
2. Run the setup script using `node src/setup/setup.js` from the `backend/src/setup` directory.
3. Confirm that the console logs the loaded `DATABASE` environment variable.
4. Verify that the admin user and default settings are created in the database without errors.
5. Start the backend normally and test login with the created admin credentials.

## Checklist

- [x] I have tested these changes  
- [x] I have commented my code where appropriate  
- [x] My changes generate no new warnings or errors  
- [x] The title of my pull request is clear and descriptive
