### PR TITLE
fix(invoice): prevent adding fields without item name (#207)

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "idurar-erp-crm",
-  "version": "4.0.0",
+  "version": "4.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "idurar-erp-crm",
-      "version": "4.0.0",
+      "version": "4.1.0",
       "license": "Fair-code License",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.509.0",


### PR DESCRIPTION
## Description

This pull request introduces the following fixes in the **Invoice** section:

1. The error message that previously showed **"Missing itemName name"** has been updated to **"Not Specified"** for better clarity.  
2. Quantity can no longer be set to `0`. If a user enters `0`, it will automatically reset to `1` when clicking anywhere on the screen.  

These changes improve validation and ensure more consistent invoice data entry.  

## Related Issues

- Closes #207

## Steps to Test

1. Navigate to the **Invoices** section.  
2. Try adding an invoice line item without an `item name`.  
   - ✅ Expected: The error message should display **"Not Specified"** instead of "Missing itemName name".  
3. Try setting the quantity of any invoice line item to `0`.  
   - ✅ Expected: Once you click anywhere outside the field, the value should automatically change to `1`.  

From 

<img width="288" height="131" alt="from" src="https://github.com/user-attachments/assets/39bdcc67-f192-4d02-b8e8-76db1326b267" />

To

<img width="270" height="142" alt="to" src="https://github.com/user-attachments/assets/4102e7a6-881e-4507-88f9-3b885b638999" />



https://github.com/user-attachments/assets/54c5199e-959b-44b5-bef8-91a0395731a3



N/A – no major UI changes, only validation and error handling updates.  



- [x] I have tested these changes  
- [] I have updated the relevant documentation (if applicable)  
- [] I have commented my code, particularly in hard-to-understand areas  
- [x] I have made corresponding changes to the codebase  
- [x] My changes generate no new warnings or errors  
- [x] The title of my pull request is clear and descriptive  
