### PR TITLE
Fix: Import Setting model in listBySettingKey.js to prevent MissingSchemaError

### DIFF
--- a/backend/src/middlewares/settings/listBySettingKey.js
+++ b/backend/src/middlewares/settings/listBySettingKey.js
@@ -1,6 +1,4 @@
-const mongoose = require('mongoose');
-
-const Model = mongoose.model('Setting');
+const Setting=require("../../models/coreModels/Setting");
 
 const listBySettingKey = async ({ settingKeyArray = [] }) => {
   try {


### PR DESCRIPTION
## Description

Fixes `MissingSchemaError` by correctly importing the `Setting` model in `listBySettingKey.js`.  
Previously, the middleware attempted to use `mongoose.model('Setting')` without requiring the schema file, which caused runtime errors.  
Now, it directly imports the model from `models/coreModels/Setting.js`.

## Related Issues

Not linked to a specific issue, but resolves the runtime error: 

## Steps to Test

1. Pull the branch and install dependencies.  
2. Run the backend server:  
   cd backend
   node src/server.js

## Screenshots (if applicable)

No.

## Checklist

- [ ✅] I have tested these changes
- [ ] I have updated the relevant documentation
- [ ✅] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the codebase
- [ ✅] My changes generate no new warnings or errors
- [✅ ] The title of my pull request is clear and descriptive
