### PR TITLE
Fixed company logo not uploading issue#1399

### DIFF
--- a/backend/src/routes/coreRoutes/coreApi.js
+++ b/backend/src/routes/coreRoutes/coreApi.js
@@ -45,9 +45,7 @@ router
 router
   .route('/setting/upload/:settingKey?')
   .patch(
-    catchErrors(
-      singleStorageUpload({ entity: 'setting', fieldName: 'settingValue', fileType: 'image' })
-    ),
+    singleStorageUpload({ entity: 'setting', fieldName: 'settingValue', fileType: 'image' }),
     catchErrors(settingController.updateBySettingKey)
   );
 router.route('/setting/updateManySetting').patch(catchErrors(settingController.updateManySetting));

--- a/frontend/src/modules/SettingModule/components/UpdateSettingForm.jsx
+++ b/frontend/src/modules/SettingModule/components/UpdateSettingForm.jsx
@@ -7,6 +7,7 @@ import { selectSettings } from '@/redux/settings/selectors';
 import { Button, Form } from 'antd';
 import Loading from '@/components/Loading';
 import useLanguage from '@/locale/useLanguage';
+import { notification } from 'antd';
 
 export default function UpdateSettingForm({ config, children, withUpload, uploadSettingKey }) {
   let { entity, settingsCategory } = config;
@@ -20,7 +21,12 @@ export default function UpdateSettingForm({ config, children, withUpload, upload
     if (withUpload) {
       if (fieldsValue.file) {
         fieldsValue.file = fieldsValue.file[0].originFileObj;
-      }
+      } else {
+        notification.error({
+          message: translate('Please select a file to upload.'),
+        });
+        return;
+      } 
       dispatch(
         settingsAction.upload({ entity, settingKey: uploadSettingKey, jsonData: fieldsValue })
       );
@@ -34,6 +40,9 @@ export default function UpdateSettingForm({ config, children, withUpload, upload
       dispatch(settingsAction.updateMany({ entity, jsonData: { settings } }));
     }
   };
+
+
+
 
   useEffect(() => {
     const current = result[settingsCategory];


### PR DESCRIPTION
Issue #1399 — Company logo not uploading

### **Cause**

- singleStorageUpload() was incorrectly wrapped in catchErrors(), which only works with async controllers.
- multerStorage is not async and does not return a Promise, causing: "Cannot read properties of undefined (reading 'catch')".

### **Fix**

- Removed catchErrors() wrapper from singleStorageUpload().
- Added an error notification when no logo is selected.

### **Solution Video** 
https://www.loom.com/share/c8f63cbc0be348128cdd9d42597af98d

### **Question**

- Where should the logo to be displayed after a successful save?