### PR TITLE
fix: #1215 default payment typo

### DIFF
--- a/backend/src/controllers/coreControllers/setup.js
+++ b/backend/src/controllers/coreControllers/setup.js
@@ -86,7 +86,7 @@ const setup = async (req, res) => {
   await PaymentMode.insertMany([
     {
       name: 'Default Payment',
-      description: 'Default Payment Mode (Cash , Wire Transfert)',
+      description: 'Default Payment Mode (Cash , Wire Transfer)',
       isDefault: true,
     },
   ]);

--- a/backend/src/setup/setup.js
+++ b/backend/src/setup/setup.js
@@ -60,7 +60,7 @@ async function setupApp() {
     await PaymentMode.insertMany([
       {
         name: 'Default Payment',
-        description: 'Default Payment Mode (Cash , Wire Transfert)',
+        description: 'Default Payment Mode (Cash , Wire Transfer)',
         isDefault: true,
       },
     ]);


### PR DESCRIPTION
## Description

- Default payment mode has typo
- Expected behavior
  "Default Payment Mode(Cash, Wire Transfer)

## Related Issues
Closes #1215 

## Screenshots
Before:
<img width="1141" height="199" alt="image" src="https://github.com/user-attachments/assets/ffa137ed-4ef9-4484-8a56-8b3394d4c5fd" />

After: 
<img width="1315" height="377" alt="image" src="https://github.com/user-attachments/assets/cb4b598f-7958-4c97-819d-8c3ac164744b" />

## Checklist

- [x] I have tested these changes
- [x] I have made corresponding changes to the codebase
- [x] My changes generate no new warnings or errors
- [x] The title of my pull request is clear and descriptive
