### PR TITLE
fix: Multiple Search API Triggered (closes #1413)

### DIFF
--- a/frontend/src/modules/ErpPanelModule/DataTable.jsx
+++ b/frontend/src/modules/ErpPanelModule/DataTable.jsx
@@ -19,7 +19,6 @@ import useLanguage from '@/locale/useLanguage';
 import { erp } from '@/redux/erp/actions';
 import { selectListItems } from '@/redux/erp/selectors';
 import { useErpContext } from '@/context/erp';
-import { generate as uniqueId } from 'shortid';
 import { useNavigate } from 'react-router-dom';
 
 import { DOWNLOAD_BASE_URL } from '@/config/serverApiConfig';
@@ -182,7 +181,7 @@ export default function DataTable({ config, extra = [] }) {
         backIcon={<ArrowLeftOutlined />}
         extra={[
           <AutoCompleteAsync
-            key={`${uniqueId()}`}
+            key="search-auto-complete"
             entity={searchConfig?.entity}
             displayLabels={['name']}
             searchFields={'name'}
@@ -191,11 +190,11 @@ export default function DataTable({ config, extra = [] }) {
             // withRedirect
             // urlToRedirect={'/customer'}
           />,
-          <Button onClick={handelDataTableLoad} key={`${uniqueId()}`} icon={<RedoOutlined />}>
+          <Button onClick={handelDataTableLoad} key="refresh-button" icon={<RedoOutlined />}>
             {translate('Refresh')}
           </Button>,
 
-          !disableAdd && <AddNewItem config={config} key={`${uniqueId()}`} />,
+          !disableAdd && <AddNewItem config={config} key="add-new-item" />,
         ]}
         style={{
           padding: '20px 0px',


### PR DESCRIPTION
## Description

This pull request fixes an issue where the search API was being triggered multiple times on initial page load, even when no data was available.

The root cause was the use of dynamically generated keys (`shortid()`) for components rendered inside `PageHeader`. Since a new key was generated on every render, React treated these components as new instances, causing them to unmount and remount repeatedly, which re-triggered side effects and search API calls.

The fix removes the use of dynamically generated keys and relies on stable component rendering to prevent unnecessary re-renders and API calls.

## Related Issues

- Fixes: Search API triggered multiple times when no data is available

## Steps to Test

1. Navigate to any module using the shared `DataTable` component (e.g. Quotes, Invoices, Payments).
2. Open the Network tab in the browser developer tools.
3. Reload the page.
4. Verify that the search API is called only once on initial load.
5. Confirm that no additional search calls are triggered unless:
   - Typing in the search input
   - Clicking refresh
   - Changing filters or pagination

## Screenshots (if applicable)

N/A – no visual UI changes.

## Checklist

- [x] I have tested these changes
- [ ] I have updated the relevant documentation (not required for this fix)
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the codebase
- [x] My changes generate no new warnings or errors
- [x] The title of my pull request is clear and descriptive
