### PR TITLE
fix: Profile Update Triggers Unexpected Logout on Page Refresh (closes #1163)

### DIFF
--- a/backend/src/controllers/middlewaresControllers/createUserController/updateProfile.js
+++ b/backend/src/controllers/middlewaresControllers/createUserController/updateProfile.js
@@ -6,6 +6,10 @@ const updateProfile = async (userModel, req, res) => {
   const reqUserName = userModel.toLowerCase();
   const userProfile = req[reqUserName];
 
+  // Get token from Authorization header
+  const authHeader = req.headers['authorization'];
+  const token = authHeader && authHeader.split(' ')[1];
+
   if (userProfile.email === 'admin@demo.com') {
     return res.status(403).json({
       success: false,
@@ -52,6 +56,7 @@ const updateProfile = async (userModel, req, res) => {
       surname: result?.surname,
       photo: result?.photo,
       role: result?.role,
+      token
     },
     message: 'we update this profile by this id: ' + userProfile._id,
   });


### PR DESCRIPTION
## Description

This pull request fixes an issue where updating the profile and navigating or reloading would log out the user.

The root cause was that the updateProfile API only returned the updated user details and did not include the JWT token. As a result, when the frontend updated the auth object in localStorage, it overwrote the previous data and lost the existing token, causing the user to be logged out on page refresh or navigation.

With this fix, the backend now includes the JWT token in the response whenever the profile is updated. This ensures that the frontend receives both the updated user details and the valid token, and the user remains logged in after updating their profile.

## Related Issues

Closes #1163

## Steps to Test

- Log in to the application
- Navigate to the Profile page
- Update profile details
- Save changes
- Refresh the page or navigate to another route
- Verify the user remains authenticated

## Screenshots (if applicable)

Reference video demonstrating the issue before the fix is available in [issue #1163 comment](https://github.com/idurar/idurar-erp-crm/issues/1163#issuecomment-3798281208).

A short reference video demonstrating the fixed behavior is attached for verification.

[fix-issue-1163.webm](https://github.com/user-attachments/assets/afcef775-5b3e-4350-8069-420a8378ad78)

## Checklist

- [x] I have tested these changes
- [ ] I have updated the relevant documentation
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the codebase
- [x] My changes generate no new warnings or errors
- [x] The title of my pull request is clear and descriptive
