### PR TITLE
fix: sanitize regex input in paginatedList search

### DIFF
--- a/backend/src/controllers/middlewaresControllers/createCRUDController/paginatedList.js
+++ b/backend/src/controllers/middlewaresControllers/createCRUDController/paginatedList.js
@@ -1,3 +1,7 @@
+function escapeRegex(string) {
+  return string.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
 const paginatedList = async (Model, req, res) => {
   const page = req.query.page || 1;
   const limit = parseInt(req.query.items) || 10;
@@ -12,7 +16,7 @@ const paginatedList = async (Model, req, res) => {
   fields = fieldsArray.length === 0 ? {} : { $or: [] };
 
   for (const field of fieldsArray) {
-    fields.$or.push({ [field]: { $regex: new RegExp(req.query.q, 'i') } });
+    fields.$or.push({ [field]: { $regex: new RegExp(escapeRegex(req.query.q || ''), 'i') } });
   }
 
   //  Query the database for a list of all results


### PR DESCRIPTION
## Description

`paginatedList.js` passes user-supplied query strings straight into `new RegExp(req.query.q, 'i')` on [line 15](https://github.com/idurar/idurar-erp-crm/blob/master/backend/src/controllers/middlewaresControllers/createCRUDController/paginatedList.js#L15) with no escaping. Regex metacharacters in `q` go directly into the RegExp constructor.

### Vulnerable Lines

**File:** [`backend/src/controllers/middlewaresControllers/createCRUDController/paginatedList.js#L15`](https://github.com/idurar/idurar-erp-crm/blob/master/backend/src/controllers/middlewaresControllers/createCRUDController/paginatedList.js#L15)

```javascript
fields.$or.push({ [field]: { $regex: new RegExp(req.query.q, 'i') } });
// req.query.q goes straight to RegExp - metacharacters are never escaped
```

### What could happen

Sending `q=%5Binvalid` (a literal `[`) makes the RegExp constructor throw, and the error message leaks back to the caller with implementation details. Patterns like `(a+)+$` cause catastrophic backtracking that hangs the server thread (ReDoS).

### How to verify

```bash
# 1. Normal search (baseline)
curl "http://localhost:8888/api/people/list?fields=firstname&q=test"
# Returns results normally

# 2. Inject broken regex metacharacter
curl "http://localhost:8888/api/people/list?fields=firstname&q=%5Binvalid"
# Server error: "Invalid regular expression: /[invalid/i: Unterminated character class"
```

### What this PR does

Adds an `escapeRegex()` helper that escapes all regex metacharacters (`.*+?^${}()|[]\`) before they reach the RegExp constructor. Normal search queries work the same way -- only the special characters get escaped.

### Evidence

Full `curl --trace-ascii` captures: [evidence gist](https://gist.github.com/theeggorchicken/0e9772ef6072fbd173acb96cce61294a)

## Related Issue

Security fix -- regex injection via unsanitized user input to `new RegExp()`.

## Steps to Test

1. Start the backend with `npm start` or via Docker
2. Hit any list endpoint with a regex metacharacter: `?fields=firstname&q=%5Binvalid`
3. Before fix: server error with regex internals. After fix: empty results, no error.

## Checklist
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.