### PR TITLE
fix: reject MongoDB operator injection in query filter params

### DIFF
--- a/backend/src/controllers/middlewaresControllers/createCRUDController/paginatedList.js
+++ b/backend/src/controllers/middlewaresControllers/createCRUDController/paginatedList.js
@@ -15,11 +15,23 @@ const paginatedList = async (Model, req, res) => {
     fields.$or.push({ [field]: { $regex: new RegExp(req.query.q, 'i') } });
   }
 
+  // Build filter condition safely: reject MongoDB operators in values
+  let filterCondition = {};
+  if (filter && equal !== undefined) {
+    if (typeof equal === 'object') {
+      return res.status(400).json({
+        success: false,
+        result: [],
+        message: 'Invalid filter value',
+      });
+    }
+    filterCondition = { [filter]: equal };
+  }
+
   //  Query the database for a list of all results
   const resultsPromise = Model.find({
     removed: false,
-
-    [filter]: equal,
+    ...filterCondition,
     ...fields,
   })
     .skip(skip)
@@ -31,8 +43,7 @@ const paginatedList = async (Model, req, res) => {
   // Counting the total documents
   const countPromise = Model.countDocuments({
     removed: false,
-
-    [filter]: equal,
+    ...filterCondition,
     ...fields,
   });
   // Resolving both promises


### PR DESCRIPTION
## Description

The `filter` and `equal` query parameters in `paginatedList.js` ([line 22](https://github.com/idurar/idurar-erp-crm/blob/master/backend/src/controllers/middlewaresControllers/createCRUDController/paginatedList.js#L22)) get interpolated directly into the MongoDB query as `[filter]: equal`. Express parses bracket notation in query strings into nested objects, so `equal[$regex]=.*` becomes `{ $regex: ".*" }` by the time it hits Mongoose. That turns the filter into an arbitrary MongoDB operator.

### Vulnerable Lines

**File:** [`backend/src/controllers/middlewaresControllers/createCRUDController/paginatedList.js#L6-L22`](https://github.com/idurar/idurar-erp-crm/blob/master/backend/src/controllers/middlewaresControllers/createCRUDController/paginatedList.js#L6-L22)

```javascript
const { sortBy = 'enabled', sortValue = -1, filter, equal } = req.query;
// ...
const resultsPromise = Model.find({
  removed: false,
  [filter]: equal,  // <-- equal can be an object like { $regex: ".*" }
  ...fields,
})
```

### What could happen

I tested this against a running instance. With `$regex`, you can extract every email address in the database:

```bash
curl "http://localhost:8888/api/people/list?filter=email&equal[$regex]=.*"
# Returns all people records regardless of any other filters
```

With `$gt`, you can enumerate all records by ID:

```bash
curl "http://localhost:8888/api/people/list?filter=_id&equal[$gt]=000000000000000000000000"
# Returns every record in the collection
```

This works against any model that uses `paginatedList` -- people, invoices, payments, products.

### What this PR does

Checks whether `equal` is a plain string before including it in the query. If Express parsed it into an object (from bracket notation like `equal[$regex]=.*`), the request gets a 400 response instead of passing the operator through to MongoDB.

### Evidence

Full `curl --trace-ascii` captures showing both `$regex` and `$gt` operator injection: [evidence gist](https://gist.github.com/theeggorchicken/0e9772ef6072fbd173acb96cce61294a)

## Related Issue

Security fix -- MongoDB operator injection via Express query string parsing.

## Steps to Test

1. Start the backend with `npm start` or Docker
2. Try `curl "http://localhost:8888/api/people/list?filter=email&equal[$regex]=.*"` with auth
3. Before fix: returns all records. After fix: 400 "Invalid filter value".

## Checklist
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.