### PR TITLE
feat: add backend Joi validation for Client CRUD operations

### DIFF
--- a/backend/src/controllers/appControllers/clientController/create.js
+++ b/backend/src/controllers/appControllers/clientController/create.js
@@ -1,0 +1,32 @@
+const mongoose = require('mongoose');
+const Model = mongoose.model('Client');
+const schema = require('./schemaValidate');
+
+const create = async (req, res) => {
+  let body = req.body;
+
+  // 1. Validate the body using Joi
+  const { error, value } = schema.validate(body);
+  if (error) {
+    return res.status(400).json({
+      success: false,
+      result: null,
+      message: error.details[0].message,
+    });
+  }
+
+  // 2. Add metadata
+  value.createdBy = req.admin._id;
+
+  // 3. Save to database
+  const result = await new Model(value).save();
+
+  // 4. Return success response
+  return res.status(200).json({
+    success: true,
+    result,
+    message: 'Client created successfully',
+  });
+};
+
+module.exports = create;

--- a/backend/src/controllers/appControllers/clientController/index.js
+++ b/backend/src/controllers/appControllers/clientController/index.js
@@ -2,12 +2,18 @@ const mongoose = require('mongoose');
 const createCRUDController = require('@/controllers/middlewaresControllers/createCRUDController');
 
 const summary = require('./summary');
+const create = require('./create'); // Import our new create method
+const update = require('./update'); // Import our new update method
 
 function modelController() {
   const Model = mongoose.model('Client');
   const methods = createCRUDController('Client');
 
+  // Override the generic methods with our custom validated ones
+  methods.create = create;
+  methods.update = update;
   methods.summary = (req, res) => summary(Model, req, res);
+
   return methods;
 }
 

--- a/backend/src/controllers/appControllers/clientController/schemaValidate.js
+++ b/backend/src/controllers/appControllers/clientController/schemaValidate.js
@@ -1,0 +1,12 @@
+const Joi = require('joi');
+const schema = Joi.object({
+  name: Joi.string().required(),
+  email: Joi.string()
+    .email({ tlds: { allow: false } })
+    .required(),
+  phone: Joi.string().allow(''),
+  country: Joi.string().allow(''),
+  address: Joi.string().allow(''),
+});
+
+module.exports = schema;

--- a/backend/src/controllers/appControllers/clientController/update.js
+++ b/backend/src/controllers/appControllers/clientController/update.js
@@ -1,0 +1,39 @@
+const mongoose = require('mongoose');
+const Model = mongoose.model('Client');
+const schema = require('./schemaValidate');
+
+const update = async (req, res) => {
+  let body = req.body;
+
+  // 1. Validate the body using Joi
+  const { error, value } = schema.validate(body);
+  if (error) {
+    return res.status(400).json({
+      success: false,
+      result: null,
+      message: error.details[0].message,
+    });
+  }
+
+  // 2. Find and update
+  const result = await Model.findOneAndUpdate({ _id: req.params.id, removed: false }, value, {
+    new: true, // return the new modified document
+    runValidators: true,
+  }).exec();
+
+  if (!result) {
+    return res.status(404).json({
+      success: false,
+      result: null,
+      message: 'No document found by this id: ' + req.params.id,
+    });
+  } else {
+    return res.status(200).json({
+      success: true,
+      result,
+      message: 'Client updated successfully',
+    });
+  }
+};
+
+module.exports = update;


### PR DESCRIPTION
The Client module currently relies solely on Mongoose for data validation at the database level. It lacks a specific validation layer to verify request bodies (like ensuring proper email formats or required fields) before executing database operations. This can lead to malformed data being saved or unhelpful API error responses.

Solution
This PR hardens the Client module by introducing explicit Joi validation at the controller level, mimicking the robust architecture already established in the Invoice and Quote modules.

Changes Made
Added  schemaValidate.js: Created a Joi schema specifically for the Client model to validate strict rules (e.g., verifying email format, requiring name, allowing blank spaces for optional fields).
Refactored clientController: Moved away from generic factory controllers for  create and  update

Added custom  create.js and update.js : These new custom controllers intercept incoming requests, run the Joi validation schema, and block invalid data with a clean 400 Bad Request early in the process.