### PR TITLE
fix: remove missing PaymentMode and Taxes model references from setup script

### DIFF
--- a/backend/src/setup/setup.js
+++ b/backend/src/setup/setup.js
@@ -51,21 +51,6 @@ async function setupApp() {
 
     console.log('👍 Settings created : Done!');
 
-    const PaymentMode = require('../models/appModels/PaymentMode');
-    const Taxes = require('../models/appModels/Taxes');
-
-    await Taxes.insertMany([{ taxName: 'Tax 0%', taxValue: '0', isDefault: true }]);
-    console.log('👍 Taxes created : Done!');
-
-    await PaymentMode.insertMany([
-      {
-        name: 'Default Payment',
-        description: 'Default Payment Mode (Cash , Wire Transfer)',
-        isDefault: true,
-      },
-    ]);
-    console.log('👍 PaymentMode created : Done!');
-
     console.log('🥳 Setup completed :Success!');
     process.exit();
   } catch (e) {


### PR DESCRIPTION
## Bug

Running `npm run setup` fails due to missing models:

```
Cannot find module '../models/appModels/PaymentMode'
Cannot find module '../models/appModels/Taxes'
```

These models are referenced in `src/setup/setup.js` but do not exist in:

```
backend/src/models/appModels/
```

This prevents contributors from completing the initial project setup locally.

## Fix

Removed invalid imports and related insert operations for:

* PaymentMode
* Taxes

These models are not present in `backend/src/models/appModels/`, so removing the references restores setup functionality without affecting runtime logic.

The setup script now completes successfully and creates:

* Admin user
* Default settings

## Steps to reproduce

1. Clone the repository
2. Navigate to the backend folder
3. Run `npm install`
4. Run `npm run setup`

**Before fix:**

Setup fails with `MODULE_NOT_FOUND` error for `PaymentMode` and `Taxes`.

**After fix:**

Setup completes successfully without errors.

## Screenshots

**Before fix**

<img width="1920" height="994" alt="err1" src="https://github.com/user-attachments/assets/ebd4f929-9c5c-45c5-a8bd-2544ebcb6cc5" />

**After fix**

<img width="1920" height="993" alt="er2" src="https://github.com/user-attachments/assets/8a8df2f5-19c1-442e-b408-e03c9e3e3a24" />

Fixes #1434

## Additional note

The setup controller (`src/controllers/coreControllers/setup.js`) also references these models and may require a similar update. I can submit a follow-up PR if needed.
