### PR TITLE
Fix env format

### DIFF
--- a/backend/.env
+++ b/backend/.env
@@ -1,6 +1,6 @@
-#DATABASE = "mongodb://localhost:27017"
-#RESEND_API = "your resend_api"
-#OPENAI_API_KEY = "your open_ai api key"
+#DATABASE="mongodb://localhost:27017"
+#RESEND_API="your resend_api"
+#OPENAI_API_KEY="your open_ai api key"
 JWT_SECRET="your_private_jwt_secret_key"
 NODE_ENV="production"
 OPENSSL_CONF='/dev/null'

--- a/backend/.env
+++ b/backend/.env
@@ -1,7 +1,7 @@
 #DATABASE = "mongodb://localhost:27017"
 #RESEND_API = "your resend_api"
 #OPENAI_API_KEY = "your open_ai api key"
-JWT_SECRET= "your_private_jwt_secret_key"
-NODE_ENV = "production"
+JWT_SECRET="your_private_jwt_secret_key"
+NODE_ENV="production"
 OPENSSL_CONF='/dev/null'
 PUBLIC_SERVER_FILE="http://localhost:8888/"


### PR DESCRIPTION
## Description

Fixed spacing inconsistencies in the example environment file.

Updated environment variable formatting to standard `.env` syntax by removing unnecessary spaces around `=`.

## Related Issues

Environment variables typically should not contain spaces around `=` since some parsers and environments may handle them inconsistently, even in sample configuration files.

## Steps to Test

1. Open the example environment file
2. Verify environment variables now follow standard formatting:
   `KEY=value`
3. Run the project with dotenv to ensure variables load correctly
