### PR TITLE
fix: Placeholder text inconsistency in Description field in Quotes

### DIFF
--- a/frontend/src/modules/ErpPanelModule/ItemRow.jsx
+++ b/frontend/src/modules/ErpPanelModule/ItemRow.jsx
@@ -72,7 +72,7 @@ export default function ItemRow({ field, remove, current = null }) {
       </Col>
       <Col className="gutter-row" span={7}>
         <Form.Item name={[field.name, 'description']}>
-          <Input placeholder="description Name" />
+          <Input placeholder="Item Description" />
         </Form.Item>
       </Col>
       <Col className="gutter-row" span={3}>


### PR DESCRIPTION
## Description

Updated the placeholder text in the Description field from `description Name` to `Item Description` for correct capitalization and better clarity.

## Related Issues

Fixes: #1451 

## Steps to Test

1. Go to Quote
2. Click on Add New Performa Invoice
3. In the Description field, the placeholder is now set to `Item Description`.

## Screenshots (if applicable)

Before(was `description Name`)
<img width="1919" height="1079" alt="image" src="https://github.com/user-attachments/assets/660fe802-4b84-4e50-bfc2-4b2c8382e9af" />

After(is `Item Description`)
<img width="1919" height="1079" alt="image" src="https://github.com/user-attachments/assets/15122b18-7770-4c2d-896f-2ce723886144" />


## Checklist

- [X] I have tested these changes
- [X] I have updated the relevant documentation
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the codebase
- [X] My changes generate no new warnings or errors
- [X] The title of my pull request is clear and descriptive
