### PR TITLE
fix: encode request query parameters

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -31,6 +31,7 @@
     "dev": "vite",
     "build": "vite build",
     "lint": "eslint . --ext js,jsx --report-unused-disable-directives --max-warnings 0",
+    "test": "node --test",
     "preview": "vite preview",
     "dev:remote": "cross-env VITE_DEV_REMOTE=remote npm run dev"
   },

--- a/frontend/src/request/buildQueryString.js
+++ b/frontend/src/request/buildQueryString.js
@@ -1,0 +1,13 @@
+export function buildQueryString(options = {}) {
+  const searchParams = new URLSearchParams();
+
+  Object.entries(options).forEach(([key, value]) => {
+    if (value !== undefined && value !== null) {
+      searchParams.set(key, value);
+    }
+  });
+
+  const queryString = searchParams.toString();
+
+  return queryString ? `?${queryString}` : '';
+}

--- a/frontend/src/request/buildQueryString.test.js
+++ b/frontend/src/request/buildQueryString.test.js
@@ -1,0 +1,37 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { buildQueryString } from './buildQueryString.js';
+
+test('returns an empty string when no options are provided', () => {
+  assert.equal(buildQueryString(), '');
+});
+
+test('encodes reserved characters and preserves their values', () => {
+  const queryString = buildQueryString({
+    q: 'ACME & Sons + Partners #1',
+    fields: 'name,email',
+  });
+  const searchParams = new URLSearchParams(queryString);
+
+  assert.equal(searchParams.get('q'), 'ACME & Sons + Partners #1');
+  assert.equal(searchParams.get('fields'), 'name,email');
+  assert.match(queryString, /%26/);
+  assert.match(queryString, /%2B/);
+  assert.match(queryString, /%23/);
+});
+
+test('preserves falsy values and omits missing values', () => {
+  const queryString = buildQueryString({
+    page: 0,
+    enabled: false,
+    filter: undefined,
+    equal: null,
+  });
+  const searchParams = new URLSearchParams(queryString);
+
+  assert.equal(searchParams.get('page'), '0');
+  assert.equal(searchParams.get('enabled'), 'false');
+  assert.equal(searchParams.has('filter'), false);
+  assert.equal(searchParams.has('equal'), false);
+});

--- a/frontend/src/request/request.js
+++ b/frontend/src/request/request.js
@@ -4,6 +4,7 @@ import { API_BASE_URL } from '@/config/serverApiConfig';
 import errorHandler from './errorHandler';
 import successHandler from './successHandler';
 import storePersist from '@/redux/storePersist';
+import { buildQueryString } from './buildQueryString';
 
 function findKeyByPrefix(object, prefix) {
   for (var property in object) {
@@ -116,9 +117,7 @@ const request = {
   filter: async ({ entity, options = {} }) => {
     try {
       includeToken();
-      let filter = options.filter ? 'filter=' + options.filter : '';
-      let equal = options.equal ? '&equal=' + options.equal : '';
-      let query = `?${filter}${equal}`;
+      const query = buildQueryString(options);
 
       const response = await axios.get(entity + '/filter' + query);
       successHandler(response, {
@@ -134,11 +133,7 @@ const request = {
   search: async ({ entity, options = {} }) => {
     try {
       includeToken();
-      let query = '?';
-      for (var key in options) {
-        query += key + '=' + options[key] + '&';
-      }
-      query = query.slice(0, -1);
+      const query = buildQueryString(options);
       // headersInstance.cancelToken = source.token;
       const response = await axios.get(entity + '/search' + query);
 
@@ -155,11 +150,7 @@ const request = {
   list: async ({ entity, options = {} }) => {
     try {
       includeToken();
-      let query = '?';
-      for (var key in options) {
-        query += key + '=' + options[key] + '&';
-      }
-      query = query.slice(0, -1);
+      const query = buildQueryString(options);
 
       const response = await axios.get(entity + '/list' + query);
 
@@ -175,11 +166,7 @@ const request = {
   listAll: async ({ entity, options = {} }) => {
     try {
       includeToken();
-      let query = '?';
-      for (var key in options) {
-        query += key + '=' + options[key] + '&';
-      }
-      query = query.slice(0, -1);
+      const query = buildQueryString(options);
 
       const response = await axios.get(entity + '/listAll' + query);
 
@@ -253,11 +240,7 @@ const request = {
   summary: async ({ entity, options = {} }) => {
     try {
       includeToken();
-      let query = '?';
-      for (var key in options) {
-        query += key + '=' + options[key] + '&';
-      }
-      query = query.slice(0, -1);
+      const query = buildQueryString(options);
       const response = await axios.get(entity + '/summary' + query);
 
       successHandler(response, {


### PR DESCRIPTION
## Summary

Fix frontend query parameter encoding for GET requests.

Search and filter values containing reserved characters such as `&`, `+`, and `#` were previously concatenated directly into URLs, causing the backend to receive truncated or incorrect query parameters. For example, searching for `ACME & Sons + Partners #1` was parsed as multiple parameters instead of one search value.

## Changes

- Add a reusable `buildQueryString` helper based on `URLSearchParams`
- Use the helper for `filter`, `search`, `list`, `listAll`, and `summary` requests
- Preserve valid falsy values such as `0` and `false` while omitting `null` and `undefined`
- Add dependency-free regression tests using Node's built-in test runner

## Testing

- `npm test` - 3 tests passed
- `npm run build` - passed
- Prettier check for changed files - passed
- Targeted ESLint check for changed files - passed

## Note

The existing `npm run lint` command fails before linting because `.eslintrc.js` uses CommonJS while `frontend/package.json` declares `type: module`. This pre-existing configuration issue is unrelated to this change.