### PR TITLE
feat: add Error Boundary to prevent app crashes

### DIFF
--- a/frontend/src/apps/IdurarOs.jsx
+++ b/frontend/src/apps/IdurarOs.jsx
@@ -7,15 +7,18 @@ import PageLoader from '@/components/PageLoader';
 import AuthRouter from '@/router/AuthRouter';
 import Localization from '@/locale/Localization';
 import { notification } from 'antd';
+import ErrorBoundary from '@/components/ErrorBoundary/ErrorBoundary';
 
 const ErpApp = lazy(() => import('./ErpApp'));
 
 const DefaultApp = () => (
   <Localization>
     <AppContextProvider>
+      <ErrorBoundary>
       <Suspense fallback={<PageLoader />}>
         <ErpApp />
       </Suspense>
+      </ErrorBoundary>
     </AppContextProvider>
   </Localization>
 );

--- a/frontend/src/components/ErrorBoundary/ErrorBoundary.jsx
+++ b/frontend/src/components/ErrorBoundary/ErrorBoundary.jsx
@@ -1,0 +1,45 @@
+import React from 'react';
+
+import { Button, notification, Result } from 'antd';
+
+class ErrorBoundary extends React.Component {
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      hasError: false,
+    };
+  }
+
+  static getDerivedStateFromError(error) {
+    return {
+      hasError: true,
+    };
+  }
+
+  componentDidCatch(error, errorInfo) {
+    console.error('Application Error:', error);
+    console.error('Error Info:', errorInfo);
+  }
+
+  render() {
+    if (this.state.hasError) {
+      return (
+        <Result
+          status="500"
+          title="Oops! Something went wrong"
+          subTitle="An unexpected error occurred."
+          extra={
+            <Button type="primary" onClick={() => window.location.reload()}>
+              Reload Application
+            </Button>
+          }
+        />
+      );
+    }
+
+    return this.props.children;
+  }
+}
+
+export default ErrorBoundary;


### PR DESCRIPTION
## Description

Describe the bug
Currently, the application does not implement a React Error Boundary around the main ERP application. If any runtime error is thrown from a child component (e.g., Dashboard, Customers, Invoices, Payments, Expenses, etc.), the entire React application crashes and displays a blank screen to the user.

This results in poor user experience and makes it difficult for users to recover from unexpected runtime exceptions.

Also, due to the implementation being missing:

No Quote MongoDB model
No Quote controller
No Quote frontend pages

This causes an app crash on a fresh install.

To Reproduce
Steps to reproduce the behavior:

Start the application locally.
Navigate to any page within the ERP application (Dashboard, Customers, Invoices, etc.).
Introduce a runtime error in any child component, for example:
throw new Error('Test Error Boundary');
Refresh the application.
Observe that the application crashes and displays a blank screen.
Expected behavior
Instead of displaying a blank screen, the application should gracefully handle unexpected runtime errors by:

Displaying a user-friendly fallback UI.
Logging the error details to the console.
Providing a recovery mechanism such as a "Reload Application" button.
Preventing the entire application from becoming unusable.
## Related Issues

If this pull request is related to any issue(s), please list them here.

## Steps to Test

Provide steps on how to test the changes introduced in this pull request.

**Screenshots**
Before :
<img width="1468" height="874" alt="Image" src="https://github.com/user-attachments/assets/80e87f3d-0a92-4284-bd91-97325c555688" />

After:
<img width="1468" height="872" alt="Image" src="https://github.com/user-attachments/assets/6b966447-f4ab-4713-8115-1ac085f55b6b" />

## Checklist

- [ ] I have tested these changes
- [ ] I have updated the relevant documentation
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the codebase
- [ ] My changes generate no new warnings or errors
- [ ] The title of my pull request is clear and descriptive
