### PR TITLE
feat: add Tax model and CRUD API endpoint (#544)

### DIFF
--- a/backend/src/models/appModels/Tax.js
+++ b/backend/src/models/appModels/Tax.js
@@ -1,0 +1,38 @@
+const mongoose = require('mongoose');
+
+const schema = new mongoose.Schema({
+  removed: {
+    type: Boolean,
+    default: false,
+  },
+  enabled: {
+    type: Boolean,
+    default: true,
+  },
+
+  taxName: {
+    type: String,
+    required: true,
+  },
+  taxValue: {
+    type: Number,
+    required: true,
+  },
+  isDefault: {
+    type: Boolean,
+    default: false,
+  },
+  createdBy: { type: mongoose.Schema.ObjectId, ref: 'Admin' },
+  created: {
+    type: Date,
+    default: Date.now,
+  },
+  updated: {
+    type: Date,
+    default: Date.now,
+  },
+});
+
+schema.plugin(require('mongoose-autopopulate'));
+
+module.exports = mongoose.model('Tax', schema);


### PR DESCRIPTION
Fixes #544

Added a new `Tax` Mongoose model at backend/src/models/appModels/Tax.js, following the same schema pattern as the existing Client model.

Fields:
- taxName (String, required)
- taxValue (Number, required)
- isDefault (Boolean, default false)
- Standard fields: removed, enabled, createdBy, created, updated

Since this project auto-generates CRUD routes and controllers for any model placed in appModels/ (via models/utils/index.js and controllers/appControllers/index.js), no manual route or controller code was needed. Adding this model automatically registers the following endpoints:

- POST /api/tax/create
- GET /api/tax/read/:id
- PATCH /api/tax/update/:id
- DELETE /api/tax/delete/:id
- GET /api/tax/search
- GET /api/tax/list
- GET /api/tax/listAll
- GET /api/tax/filter
- GET /api/tax/summary

Tested locally by starting the backend and calling POST /api/tax/create with a sample payload — confirmed the document is created and returned correctly.