### PR TITLE
fix: prevent IDOR in admin read and password update endpoints

### DIFF
--- a/backend/src/controllers/middlewaresControllers/createUserController/read.js
+++ b/backend/src/controllers/middlewaresControllers/createUserController/read.js
@@ -3,9 +3,22 @@ const mongoose = require('mongoose');
 const read = async (userModel, req, res) => {
   const User = mongoose.model(userModel);
 
+  const reqUserName = userModel.toLowerCase();
+  const userProfile = req[reqUserName];
+
+  const authenticatedId = userProfile._id.toString();
+
+  if (req.params.id !== authenticatedId) {
+    return res.status(403).json({
+      success: false,
+      result: null,
+      message: 'Forbidden',
+    });
+  }
+
   // Find document by id
   const tmpResult = await User.findOne({
-    _id: req.params.id,
+    _id: authenticatedId,
     removed: false,
   }).exec();
   // If no results found, return document not found

--- a/backend/src/controllers/middlewaresControllers/createUserController/updatePassword.js
+++ b/backend/src/controllers/middlewaresControllers/createUserController/updatePassword.js
@@ -25,6 +25,16 @@ const updatePassword = async (userModel, req, res) => {
     });
   }
 
+  const authenticatedId = userProfile._id.toString();
+
+  if (req.params.id !== authenticatedId) {
+    return res.status(403).json({
+      success: false,
+      result: null,
+      message: 'Forbidden',
+    });
+  }
+
   const salt = uniqueId();
 
   const passwordHash = bcrypt.hashSync(salt + password);
@@ -35,7 +45,7 @@ const updatePassword = async (userModel, req, res) => {
   };
 
   const resultPassword = await UserPassword.findOneAndUpdate(
-    { user: req.params.id, removed: false },
+    { user: authenticatedId, removed: false },
     { $set: UserPasswordData },
     {
       new: true, // return the new result instead of the old one


### PR DESCRIPTION
## Description

This pull request fixes an Insecure Direct Object Reference (IDOR) vulnerability in the admin endpoints.

The fix ensures that an authenticated admin can only access and update their own account by verifying that the authenticated user's ID matches the requested route parameter before performing the operation.

## Related Issues

Closes #1470

## Steps to Test

1. Log in as an admin user.
2. Try to access another admin's profile using:
   - `GET /api/admin/read/:id`
3. Try to update another admin's password using:
   - `PATCH /api/admin/password-update/:id`
4. Verify that both requests return **403 Forbidden**.
5. Verify that reading your own profile and updating your own password still work correctly.

## Screenshots (if applicable)

N/A

## Checklist

- [x] I have tested these changes
- [ ] I have updated the relevant documentation
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the codebase
- [x] My changes generate no new warnings or errors
- [x] The title of my pull request is clear and descriptive