### PR TITLE
refactor: share invoice subtotal/tax/total calculation

### DIFF
--- a/backend/src/controllers/appControllers/invoiceController/calculateTotals.js
+++ b/backend/src/controllers/appControllers/invoiceController/calculateTotals.js
@@ -1,0 +1,28 @@
+const { calculate } = require('@/helpers');
+
+/**
+ * Calculate item line totals, subtotal, tax total, and grand total for an invoice.
+ * Mutates each item to set item.total (same behavior as the previous inline logic).
+ *
+ * @param {Array} items - Invoice line items with quantity and price
+ * @param {number} taxRate - Tax rate as a percentage (e.g. 10 for 10%)
+ * @returns {{ subTotal: number, taxTotal: number, total: number, items: Array }}
+ */
+const calculateTotals = (items = [], taxRate = 0) => {
+  let subTotal = 0;
+
+  items.map((item) => {
+    let total = calculate.multiply(item['quantity'], item['price']);
+    // sub total
+    subTotal = calculate.add(subTotal, total);
+    // item total
+    item['total'] = total;
+  });
+
+  const taxTotal = calculate.multiply(subTotal, taxRate / 100);
+  const total = calculate.add(subTotal, taxTotal);
+
+  return { subTotal, taxTotal, total, items };
+};
+
+module.exports = calculateTotals;

--- a/backend/src/controllers/appControllers/invoiceController/create.js
+++ b/backend/src/controllers/appControllers/invoiceController/create.js
@@ -5,6 +5,7 @@ const Model = mongoose.model('Invoice');
 const { calculate } = require('@/helpers');
 const { increaseBySettingKey } = require('@/middlewares/settings');
 const schema = require('./schemaValidate');
+const calculateTotals = require('./calculateTotals');
 
 const create = async (req, res) => {
   let body = req.body;
@@ -21,21 +22,7 @@ const create = async (req, res) => {
 
   const { items = [], taxRate = 0, discount = 0 } = value;
 
-  // default
-  let subTotal = 0;
-  let taxTotal = 0;
-  let total = 0;
-
-  //Calculate the items array with subTotal, total, taxTotal
-  items.map((item) => {
-    let total = calculate.multiply(item['quantity'], item['price']);
-    //sub total
-    subTotal = calculate.add(subTotal, total);
-    //item total
-    item['total'] = total;
-  });
-  taxTotal = calculate.multiply(subTotal, taxRate / 100);
-  total = calculate.add(subTotal, taxTotal);
+  const { subTotal, taxTotal, total } = calculateTotals(items, taxRate);
 
   body['subTotal'] = subTotal;
   body['taxTotal'] = taxTotal;
@@ -43,7 +30,6 @@ const create = async (req, res) => {
   body['items'] = items;
 
   let paymentStatus = calculate.sub(total, discount) === 0 ? 'paid' : 'unpaid';
-
   body['paymentStatus'] = paymentStatus;
   body['createdBy'] = req.admin._id;
 

--- a/backend/src/controllers/appControllers/invoiceController/update.js
+++ b/backend/src/controllers/appControllers/invoiceController/update.js
@@ -6,6 +6,7 @@ const custom = require('@/controllers/pdfController');
 
 const { calculate } = require('@/helpers');
 const schema = require('./schemaValidate');
+const calculateTotals = require('./calculateTotals');
 
 const update = async (req, res) => {
   let body = req.body;
@@ -37,21 +38,7 @@ const update = async (req, res) => {
     });
   }
 
-  // default
-  let subTotal = 0;
-  let taxTotal = 0;
-  let total = 0;
-
-  //Calculate the items array with subTotal, total, taxTotal
-  items.map((item) => {
-    let total = calculate.multiply(item['quantity'], item['price']);
-    //sub total
-    subTotal = calculate.add(subTotal, total);
-    //item total
-    item['total'] = total;
-  });
-  taxTotal = calculate.multiply(subTotal, taxRate / 100);
-  total = calculate.add(subTotal, taxTotal);
+  const { subTotal, taxTotal, total } = calculateTotals(items, taxRate);
 
   body['subTotal'] = subTotal;
   body['taxTotal'] = taxTotal;


### PR DESCRIPTION
## Summary
- Extract duplicated invoice line-item total logic (subtotal, tax total, grand total) from `create.js` and `update.js` into a shared `calculateTotals` helper.
- Both create and update now call the same function so totals stay consistent and only need to be maintained in one place.

## Test plan
- [x] Ran a side-by-side Node script comparing the shared helper to the previous inline logic (single item, multi-item + tax, decimal prices, zero quantity, currency rounding) — all matched
- [ ] Manually create an invoice in the UI and confirm subtotal, tax, and total match expectations
- [ ] Manually update an invoice's items/tax rate and confirm totals recalculate correctly