### PR TITLE
fix: add missing dayjs import in helpers.js

### DIFF
--- a/frontend/src/utils/helpers.js
+++ b/frontend/src/utils/helpers.js
@@ -1,3 +1,5 @@
+import dayjs from 'dayjs';
+
 export function get(obj, key) {
   return key.split('.').reduce(function (o, x) {
     return o === undefined || o === null ? o : o[x];


### PR DESCRIPTION
## Description
The `isDate()` helper in `frontend/src/utils/helpers.js` calls `dayjs(date, format)`, 
but `dayjs` was never imported in the file. This caused a runtime `ReferenceError` 
whenever `isDate()` was executed.

## Fix
Added the missing import statement at the top of the file:
`import dayjs from 'dayjs';`

`dayjs` is already listed as a project dependency in `frontend/package.json`, 
so no new dependencies were added.

Fixes #1479