### PR TITLE
fix: require auth token for PDF download endpoint (#1428)

### DIFF
--- a/backend/src/app.js
+++ b/backend/src/app.js
@@ -39,7 +39,7 @@ app.use(compression());
 app.use('/api', coreAuthRouter);
 app.use('/api', adminAuth.isValidAuthToken, coreApiRouter);
 app.use('/api', adminAuth.isValidAuthToken, erpApiRouter);
-app.use('/download', coreDownloadRouter);
+app.use('/download', adminAuth.isValidAuthToken, coreDownloadRouter);
 app.use('/public', corePublicRouter);
 
 // If that above routes didnt work, we 404 them and forward to error handler

--- a/frontend/src/modules/DashboardModule/components/RecentTable/index.jsx
+++ b/frontend/src/modules/DashboardModule/components/RecentTable/index.jsx
@@ -8,7 +8,6 @@ import { useDispatch } from 'react-redux';
 import { erp } from '@/redux/erp/actions';
 import useLanguage from '@/locale/useLanguage';
 import { useNavigate } from 'react-router-dom';
-import { DOWNLOAD_BASE_URL } from '@/config/serverApiConfig';
 
 export default function RecentTable({ ...props }) {
   const translate = useLanguage();
@@ -44,7 +43,7 @@ export default function RecentTable({ ...props }) {
     navigate(`/${entity}/update/${record._id}`);
   };
   const handleDownload = (record) => {
-    window.open(`${DOWNLOAD_BASE_URL}${entity}/${entity}-${record._id}.pdf`, '_blank');
+    request.download({ entity, id: record._id });
   };
 
   dataTableColumns = [

--- a/frontend/src/modules/ErpPanelModule/DataTable.jsx
+++ b/frontend/src/modules/ErpPanelModule/DataTable.jsx
@@ -21,7 +21,7 @@ import { selectListItems } from '@/redux/erp/selectors';
 import { useErpContext } from '@/context/erp';
 import { useNavigate } from 'react-router-dom';
 
-import { DOWNLOAD_BASE_URL } from '@/config/serverApiConfig';
+import { request } from '@/request';
 
 function AddNewItem({ config }) {
   const navigate = useNavigate();
@@ -91,7 +91,7 @@ export default function DataTable({ config, extra = [] }) {
     navigate(`/${entity}/update/${record._id}`);
   };
   const handleDownload = (record) => {
-    window.open(`${DOWNLOAD_BASE_URL}${entity}/${entity}-${record._id}.pdf`, '_blank');
+    request.download({ entity, id: record._id });
   };
 
   const handleDelete = (record) => {

--- a/frontend/src/modules/ErpPanelModule/ReadItem.jsx
+++ b/frontend/src/modules/ErpPanelModule/ReadItem.jsx
@@ -19,7 +19,7 @@ import { generate as uniqueId } from 'shortid';
 
 import { selectCurrentItem } from '@/redux/erp/selectors';
 
-import { DOWNLOAD_BASE_URL } from '@/config/serverApiConfig';
+import { request } from '@/request';
 import { useMoney, useDate } from '@/settings';
 import useMail from '@/hooks/useMail';
 import { useNavigate } from 'react-router-dom';
@@ -152,10 +152,7 @@ export default function ReadItem({ config, selectedItem }) {
           <Button
             key={`${uniqueId()}`}
             onClick={() => {
-              window.open(
-                `${DOWNLOAD_BASE_URL}${entity}/${entity}-${currentErp._id}.pdf`,
-                '_blank'
-              );
+              request.download({ entity, id: currentErp._id });
             }}
             icon={<FilePdfOutlined />}
           >

--- a/frontend/src/modules/PaymentModule/ReadPaymentModule/components/ReadItem.jsx
+++ b/frontend/src/modules/PaymentModule/ReadPaymentModule/components/ReadItem.jsx
@@ -18,7 +18,7 @@ import { generate as uniqueId } from 'shortid';
 
 import { selectCurrentItem } from '@/redux/erp/selectors';
 
-import { DOWNLOAD_BASE_URL } from '@/config/serverApiConfig';
+import { request } from '@/request';
 import { useMoney } from '@/settings';
 
 import useMail from '@/hooks/useMail';
@@ -92,10 +92,7 @@ export default function ReadItem({ config, selectedItem }) {
           <Button
             key={`${uniqueId()}`}
             onClick={() => {
-              window.open(
-                `${DOWNLOAD_BASE_URL}${entity}/${entity}-${currentErp._id}.pdf`,
-                '_blank'
-              );
+              request.download({ entity, id: currentErp._id });
             }}
             icon={<FilePdfOutlined />}
           >

--- a/frontend/src/request/request.js
+++ b/frontend/src/request/request.js
@@ -1,5 +1,5 @@
 import axios from 'axios';
-import { API_BASE_URL } from '@/config/serverApiConfig';
+import { API_BASE_URL, DOWNLOAD_BASE_URL } from '@/config/serverApiConfig';
 
 import errorHandler from './errorHandler';
 import successHandler from './successHandler';
@@ -108,6 +108,25 @@ const request = {
         notifyOnFailed: true,
       });
       return response.data;
+    } catch (error) {
+      return errorHandler(error);
+    }
+  },
+
+  download: async ({ entity, id }) => {
+    try {
+      includeToken();
+      const fileName = `${entity}-${id}.pdf`;
+      const response = await axios.get(`${DOWNLOAD_BASE_URL}${entity}/${fileName}`, {
+        responseType: 'blob',
+      });
+      const url = window.URL.createObjectURL(response.data);
+      const link = document.createElement('a');
+      link.href = url;
+      link.download = fileName;
+      link.click();
+      window.URL.revokeObjectURL(url);
+      return true;
     } catch (error) {
       return errorHandler(error);
     }


### PR DESCRIPTION
The /download route was mounted without the isValidAuthToken middleware, allowing anyone to download any invoice, quote or payment PDF by guessing or enumerating record ids (#1428).

- mount adminAuth.isValidAuthToken on the /download route
- add request.download() which fetches the PDF via axios with the Authorization header and saves it as a blob, since window.open cannot send auth headers
- switch all four download call sites to request.download()

## Description
The `/download` route was mounted without the `isValidAuthToken` middleware, allowing anyone to download any invoice, quote or payment PDF **without logging in**, just by guessing or enumerating record ids.

Changes:

- **Backend**: mount `adminAuth.isValidAuthToken` on the `/download` route in `backend/src/app.js` — the same middleware already protecting the `/api` routes (one line).
- **Frontend**: `window.open()` cannot send an `Authorization` header, so the backend fix alone would break the download buttons. Added `request.download()` in `frontend/src/request/request.js`, which fetches the PDF via axios with the auth token (`responseType: 'blob'`) and saves it, following the existing `includeToken()` / `errorHandler` pattern. Switched all four download call sites (ERP panel DataTable and ReadItem, Payment ReadItem, Dashboard RecentTable) to use it.

Note: complementary to #1484 / #1476 / #1473, which fix the password-update IDOR from the same issue but do not touch the download route.

## Related Issues
Fixes the unauthenticated PDF download part of #1428.

## Steps to Test

1. Run the backend and log in to get a token.
2. Without any token, request:
   `GET http://localhost:8888/download/invoice/invoice-<id>.pdf`
   → **401 Unauthorized** (before this fix: returned the PDF).
3. Repeat with a valid `Authorization: Bearer <token>` header
   → **200**, valid PDF with correct `Content-Type: application/pdf` and attachment filename.
4. In the UI, click **Download PDF** on an invoice/quote/payment list or detail page → the PDF downloads as before.

## Screenshots (if applicable)

N/A — no visual changes; download buttons behave the same for logged-in users.

## Checklist

- [x] I have tested these changes
- [ ] I have updated the relevant documentation
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the codebase
- [x] My changes generate no new warnings or errors
- [x] The title of my pull request is clear and descriptive

Two boxes stay unchecked honestly: no documentation exists for this route (nothing to update), and the code needed no comments — it follows existing patterns. Checking boxes that don't apply looks worse than leaving them.
