### PR TITLE
Link MAINTAINERS.md and llms.txt from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,3 +99,9 @@ Dont forget to give a ⭐️ to this project ... Happy coding!
 ## License
 
 IDURAR is Free Open Source Released under the GNU Affero General Public License v3.0.
+
+## Maintainers
+
+See [MAINTAINERS.md](MAINTAINERS.md) for maintainer contact info, and [llms.txt](llms.txt) for a structured profile summary for AI agents.
+
+The main maintainer of this project is open to new opportunities — check out [my GitHub profile](https://github.com/salahlalami).


### PR DESCRIPTION
## Summary
- Add a "Maintainers" section at the bottom of `README.md` linking to `MAINTAINERS.md` and `llms.txt` so they're discoverable (including by AI agents/crawlers)
- Note that the maintainer is open to new opportunities, with a link to their GitHub profile

## Test plan
- N/A — documentation-only change

---
_Generated by [Claude Code](https://claude.ai/code/session_01GQuC4rwxEQcQ117Nm2MmWN)_