### PR TITLE
fix: reset scroll position to top on route navigation

### DIFF
--- a/frontend/src/components/ScrollToTop/index.jsx
+++ b/frontend/src/components/ScrollToTop/index.jsx
@@ -1,0 +1,19 @@
+import { useEffect } from 'react';
+import { useLocation } from 'react-router-dom';
+
+/**
+ * ScrollToTop resets the window scroll position to the top
+ * whenever the route (pathname) changes.
+ *
+ * This prevents the issue where navigating between sidebar links
+ * (e.g., Products → Customers) keeps the previous page's scroll position.
+ */
+export default function ScrollToTop() {
+  const { pathname } = useLocation();
+
+  useEffect(() => {
+    window.scrollTo(0, 0);
+  }, [pathname]);
+
+  return null;
+}

--- a/frontend/src/router/AppRouter.jsx
+++ b/frontend/src/router/AppRouter.jsx
@@ -4,6 +4,7 @@ import {} from 'react-router-dom';
 import {} from 'react-router-dom';
 import { Navigate, useLocation, useRoutes } from 'react-router-dom';
 import { useAppContext } from '@/context/appContext';
+import ScrollToTop from '@/components/ScrollToTop';
 
 import routes from './routes';
 
@@ -40,5 +41,10 @@ export default function AppRouter() {
 
   let element = useRoutes(routesList);
 
-  return element;
+  return (
+    <>
+      <ScrollToTop />
+      {element}
+    </>
+  );
 }


### PR DESCRIPTION
## Description

Adds a `ScrollToTop` component that listens to `pathname` changes via `useLocation` 
and calls `window.scrollTo(0, 0)` on every route change. This fixes the issue where 
navigating between sidebar links (e.g., Products → Customers) retained the previous 
page's scroll position instead of resetting to top.

## Related Issues

Fixes #1496

## Steps to Test

1. Go to a page with a long list (e.g., Products or Invoices)
2. Scroll down
3. Click a different sidebar link (e.g., Customers)
4. Confirm the new page loads scrolled to the top

## Screenshots

N/A (behavioral fix, no visual change)

## Checklist

- [x] I have tested these changes
- [ ] I have updated the relevant documentation
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the codebase
- [x] My changes generate no new warnings or errors
- [x] The title of my pull request is clear and descriptive